### PR TITLE
traceManager - fix lastChanges check

### DIFF
--- a/src/trace/traceManager.js
+++ b/src/trace/traceManager.js
@@ -205,7 +205,7 @@ TraceManager.prototype.getMemoryAt = function (stepIndex, callback) {
     return callback(check, null)
   }
   var lastChanges = util.findLowerBoundValue(stepIndex, this.traceCache.memoryChanges)
-  if (lastChanges === undefined) return callback('no memory found', null)
+  if (!lastChanges && lastChanges !== 0) return callback('no memory found', null)
   callback(null, this.trace[lastChanges].memory)
 }
 


### PR DESCRIPTION
`findLowerBoundValue` can return `null`.
https://github.com/ethereum/remix/blob/5f5c4c7ce396edb908488db878519d086659b77f/src/helpers/util.js#L70-L73

Changed logic to check for non-zero falsiness.