### PR TITLE
Support async / await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
-  "plugins": ["check-es2015-constants",
+  "plugins": ["fast-async",
+              "check-es2015-constants",
               "transform-es2015-arrow-functions",
               "transform-es2015-block-scoped-functions",
               "transform-es2015-block-scoping",
@@ -15,7 +16,6 @@
               "transform-es2015-shorthand-properties",
               "transform-es2015-spread",
               "transform-es2015-sticky-regex",
-              "transform-es2015-template-literals",
               "transform-es2015-unicode-regex",
-              "transform-regenerator"]
+            ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 lint.xml
 .vscode
 test-browser/reports/*
+babelify-src

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "start_eth": "npm run warning_message; eth -j --rpccorsdomain '*'",
     "start_geth": "npm run warning_message; geth --rpc --rpcapi 'web3,eth,debug' --rpcport 8545 --rpccorsdomain '*'",
     "build": "mkdir build; browserify src/index.js -g yo-yoify -o build/app.js -t [ babelify ]; babel --plugins=transform-es2015-template-literals build/app.js --out-file build/app.js",
-    "test": "babel src --out-dir babelify-src; tape ./test/tests.js",
+    "test": "standard; babel src --out-dir babelify-src; tape ./test/tests.js",
     "serve": "http-server .",
     "nightwatch_local": "nightwatch --config nightwatch.js --env local",
     "nightwatch_remote_firefox": "nightwatch --config nightwatch.js --env default",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",
+    "babel-eslint": "^7.1.1",
     "babel-plugin-check-es2015-constants": "^6.8.0",
     "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
     "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
@@ -37,8 +38,10 @@
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
     "babel-plugin-transform-regenerator": "^6.16.1",
+    "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "ethereumjs-util": "^4.5.0",
+    "fast-async": "^6.1.2",
     "http-server": "^0.9.0",
     "nightwatch": "^0.9.5",
     "solc": "^0.4.3",
@@ -53,8 +56,8 @@
     "start_node": "./runNode.sh",
     "start_eth": "npm run warning_message; eth -j --rpccorsdomain '*'",
     "start_geth": "npm run warning_message; geth --rpc --rpcapi 'web3,eth,debug' --rpcport 8545 --rpccorsdomain '*'",
-    "build": "mkdir build; browserify src/index.js -g yo-yoify -o build/app.js; babel build/app.js --out-file build/app.js",
-    "test": "standard && tape ./test/tests.js",
+    "build": "mkdir build; browserify src/index.js -g yo-yoify -o build/app.js -t [ babelify ]; babel --plugins=transform-es2015-template-literals build/app.js --out-file build/app.js",
+    "test": "babel src --out-dir babelify-src; tape ./test/tests.js",
     "serve": "http-server .",
     "nightwatch_local": "nightwatch --config nightwatch.js --env local",
     "nightwatch_remote_firefox": "nightwatch --config nightwatch.js --env default",
@@ -79,6 +82,7 @@
       "node_modules/*",
       "build/*",
       "test/resources/*"
-    ]
+    ],
+    "parser": "babel-eslint"
   }
 }

--- a/test/astwalker.js
+++ b/test/astwalker.js
@@ -1,6 +1,6 @@
 'use strict'
 var tape = require('tape')
-var AstWalker = require('../src/util/astWalker')
+var AstWalker = require('../babelify-src/util/astWalker')
 var node = require('./resources/ast')
 
 tape('ASTWalker', function (t) {

--- a/test/codeManager.js
+++ b/test/codeManager.js
@@ -1,10 +1,10 @@
 'use strict'
 var tape = require('tape')
-var Web3Providers = require('../src/web3Provider/web3Providers')
-var TraceManager = require('../src/trace/traceManager')
-var CodeManager = require('../src/code/codeManager')
+var Web3Providers = require('../babelify-src/web3Provider/web3Providers')
+var TraceManager = require('../babelify-src/trace/traceManager')
+var CodeManager = require('../babelify-src/code/codeManager')
 var web3Test = require('./resources/testWeb3')
-var util = require('../src/helpers/global')
+var util = require('../babelify-src/helpers/global')
 
 tape('CodeManager', function (t) {
   var codeManager

--- a/test/disassembler.js
+++ b/test/disassembler.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var tape = require('tape')
-var disassemble = require('..').code.disassembler.disassemble
+var disassemble = require('../babelify-src/code/disassembler').disassemble
 
 tape('Disassembler', function (t) {
   t.test('empty', function (st) {

--- a/test/eventManager.js
+++ b/test/eventManager.js
@@ -1,6 +1,6 @@
 'use strict'
 var tape = require('tape')
-var EventManager = require('../src/lib/eventManager')
+var EventManager = require('../babelify-src/lib/eventManager')
 tape('eventManager', function (t) {
   t.test('eventManager', function (st) {
     var events = new EventManager()

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict'
 var tape = require('tape')
-var init = require('../src/helpers/init')
+var init = require('../babelify-src/helpers/init')
 tape('index', function (t) {
   t.test('loadContext - web3', function (st) {
     var web3 = init.loadWeb3()

--- a/test/solidity/decodeInfo.js
+++ b/test/solidity/decodeInfo.js
@@ -1,7 +1,7 @@
 'use strict'
 var tape = require('tape')
 var compiler = require('solc')
-var index = require('../../src/index')
+var index = require('../../babelify-src/index')
 var contracts = require('./contracts/miscContracts')
 var simplecontracts = require('./contracts/simpleContract')
 

--- a/test/solidity/storageDecoder.js
+++ b/test/solidity/storageDecoder.js
@@ -1,7 +1,7 @@
 'use strict'
 var tape = require('tape')
 var compiler = require('solc')
-var stateDecoder = require('../../src/index').solidity.stateDecoder
+var stateDecoder = require('../../babelify-src/index').solidity.stateDecoder
 
 tape('solidity', function (t) {
   t.test('storage decoder', function (st) {

--- a/test/solidity/storageLocation.js
+++ b/test/solidity/storageLocation.js
@@ -1,7 +1,7 @@
 'use strict'
 var tape = require('tape')
 var compiler = require('solc')
-var index = require('../../src/index')
+var index = require('../../babelify-src/index')
 var contracts = require('./contracts/miscContracts')
 
 tape('solidity', function (t) {

--- a/test/sourceMappingDecoder.js
+++ b/test/sourceMappingDecoder.js
@@ -1,6 +1,6 @@
 'use strict'
 var tape = require('tape')
-var SourceMappingDecoder = require('../src/util/sourceMappingDecoder')
+var SourceMappingDecoder = require('../babelify-src/util/sourceMappingDecoder')
 var compiler = require('solc')
 
 tape('SourceMappingDecoder', function (t) {

--- a/test/traceManager.js
+++ b/test/traceManager.js
@@ -1,8 +1,8 @@
 'use strict'
-var TraceManager = require('../src/trace/traceManager')
+var TraceManager = require('../babelify-src/trace/traceManager')
 var tape = require('tape')
-var Web3Providers = require('../src/web3Provider/web3Providers')
-var util = require('../src/helpers/global')
+var Web3Providers = require('../babelify-src/web3Provider/web3Providers')
+var util = require('../babelify-src/helpers/global')
 var web3Test = require('./resources/testWeb3')
 
 tape('TraceManager', function (t) {

--- a/test/util.js
+++ b/test/util.js
@@ -1,8 +1,8 @@
 'use strict'
 var sourceMapping = require('./resources/sourceMapping')
-var index = require('../src/index')
+var index = require('../babelify-src/index')
 var tape = require('tape')
-var util = require('../src/helpers/util')
+var util = require('../babelify-src/helpers/util')
 
 tape('Util', function (t) {
   t.test('lowerbound', function (st) {


### PR DESCRIPTION
use fast-async module
https://www.npmjs.com/package/fast-async

build steps are a bit different now:
 - browserify with using yoyo and babel (except template-literals transform, cause if we include it, that will hide the yoyo transformation)
 - run transform-es2015-template-literals

for testing, we also need to transform the code (afaik async/await is not yet supported by nodejs)
