### PR TITLE
fix caret placement for struct data

### DIFF
--- a/src/ui/styles/treeView.js
+++ b/src/ui/styles/treeView.js
@@ -22,7 +22,6 @@ module.exports = {
     'font-family': 'arial,sans-serif'
   },
   caret: {
-    'position': 'absolute',
     'margin-top': '3px'
   },
   data: {


### PR DESCRIPTION
fixes placement of caret symbol to collapse and expand struct data under State and Locals.