### PR TITLE
Fix input param

### DIFF
--- a/remix-lib/src/execution/txFormat.js
+++ b/remix-lib/src/execution/txFormat.js
@@ -49,8 +49,9 @@ module.exports = {
     var data = ''
     var dataHex = ''
 
-    if (params.indexOf('0x') === 0) {
-      dataHex = params.replace('0x', '')
+    if (params.indexOf('raw:0x') === 0) {
+      // in that case we consider that the input is already encoded and *does not* contain the method signature
+      dataHex = params.replace('raw:0x', '')
       data = Buffer.from(dataHex, 'hex')
     } else {
       try {


### PR DESCRIPTION
user input considered as raw only if prepend by `raw:`