### PR TITLE
Display reason for revert (Solidity 0.4.22 feature)

### DIFF
--- a/remix-lib/src/execution/txExecution.js
+++ b/remix-lib/src/execution/txExecution.js
@@ -1,4 +1,5 @@
 'use strict'
+var ethJSABI = require('ethereumjs-abi')
 
 module.exports = {
   /**
@@ -82,7 +83,14 @@ module.exports = {
       msg = `\tThe transaction ran out of gas. Please increase the Gas Limit.\n`
       ret.error = true
     } else if (exceptionError === errorCode.REVERT) {
-      msg = `\tThe transaction has been reverted to the initial state.\nNote: The constructor should be payable if you send value.`
+      var returnData = txResult.result.vm.return
+      // It is the hash of Error(string)
+      if (returnData && (returnData.slice(0, 4).toString('hex') === '08c379a0')) {
+        var reason = ethJSABI.rawDecode(['string'], returnData.slice(4))[0]
+        msg = `\tThe transaction has been reverted to the initial state.\nReason provided by the contract: "${reason}".`
+      } else {
+        msg = `\tThe transaction has been reverted to the initial state.\nNote: The constructor should be payable if you send value.`
+      }
       ret.error = true
     } else if (exceptionError === errorCode.STATIC_STATE_CHANGE) {
       msg = `\tState changes is not allowed in Static Call context\n`

--- a/remix-lib/src/execution/txExecution.js
+++ b/remix-lib/src/execution/txExecution.js
@@ -72,22 +72,23 @@ module.exports = {
     if (!txResult.result.vm.exceptionError) {
       return ret
     }
-    var error = `VM error: ${txResult.result.vm.exceptionError}.\n`
+    var exceptionError = txResult.result.vm.exceptionError.error || ''
+    var error = `VM error: ${exceptionError}.\n`
     var msg
-    if (txResult.result.vm.exceptionError === errorCode.INVALID_OPCODE) {
+    if (exceptionError === errorCode.INVALID_OPCODE) {
       msg = `\t\n\tThe execution might have thrown.\n`
       ret.error = true
-    } else if (txResult.result.vm.exceptionError === errorCode.OUT_OF_GAS) {
+    } else if (exceptionError === errorCode.OUT_OF_GAS) {
       msg = `\tThe transaction ran out of gas. Please increase the Gas Limit.\n`
       ret.error = true
-    } else if (txResult.result.vm.exceptionError === errorCode.REVERT) {
+    } else if (exceptionError === errorCode.REVERT) {
       msg = `\tThe transaction has been reverted to the initial state.\nNote: The constructor should be payable if you send value.`
       ret.error = true
-    } else if (txResult.result.vm.exceptionError === errorCode.STATIC_STATE_CHANGE) {
+    } else if (exceptionError === errorCode.STATIC_STATE_CHANGE) {
       msg = `\tState changes is not allowed in Static Call context\n`
       ret.error = true
     }
-    ret.message = `${error}${txResult.result.vm.exceptionError}${msg}\tDebug the transaction to get more information.`
+    ret.message = `${error}${exceptionError}${msg}\tDebug the transaction to get more information.`
     return ret
   }
 }


### PR DESCRIPTION
Implements https://github.com/ethereum/solidity/issues/1686

Example output on Remix:
```
call to C.g errored: VM error: revert.
revert	The transaction has been reverted to the initial state.
Reason provided by the contract: Not enough Ether provided..	Debug the transaction to get more information.
```