### PR TITLE
Static Analysis: Bugfix constant function check, Similar var names al…

### DIFF
--- a/remix-solidity/src/analysis/modules/checksEffectsInteraction.js
+++ b/remix-solidity/src/analysis/modules/checksEffectsInteraction.js
@@ -33,10 +33,10 @@ function report (contracts, multipleContractsWithSameName) {
     contract.functions.forEach((func) => {
       if (isPotentialVulnerableFunction(func, getContext(callGraph, contract, func))) {
         var funcName = common.getFullQuallyfiedFuncDefinitionIdent(contract.node, func.node, func.parameters)
-        var comments = (hasModifiers) ? '<br/><i>Note:</i> Modifiers are currently not considered by this static analysis.' : ''
-        comments += (multipleContractsWithSameName) ? '<br/><i>Note:</i> Import aliases are currently not supported by this static analysis.' : ''
+        var comments = (hasModifiers) ? 'Note: Modifiers are currently not considered by this static analysis.' : ''
+        comments += (multipleContractsWithSameName) ? 'Note: Import aliases are currently not supported by this static analysis.' : ''
         warnings.push({
-          warning: `Potential Violation of Checks-Effects-Interaction pattern in <i>${funcName}</i>: Could potentially lead to re-entrancy vulnerability. ${comments}`,
+          warning: `Potential Violation of Checks-Effects-Interaction pattern in ${funcName}: Could potentially lead to re-entrancy vulnerability. ${comments}`,
           location: func.src,
           more: 'http://solidity.readthedocs.io/en/develop/security-considerations.html#re-entrancy'
         })

--- a/remix-solidity/src/analysis/modules/constantFunctions.js
+++ b/remix-solidity/src/analysis/modules/constantFunctions.js
@@ -16,7 +16,8 @@ function constantFunctions () {
               common.isLocalCallGraphRelevantNode(node) ||
               common.isInlineAssembly(node) ||
               common.isNewExpression(node) ||
-              common.isSelfdestructCall(node)
+              common.isSelfdestructCall(node) ||
+              common.isDeleteUnaryOperation(node)
   )
 
   this.report = this.abstractAst.build_report(report)
@@ -45,8 +46,8 @@ function report (contracts, multipleContractsWithSameName) {
     contract.functions.filter((func) => common.hasFunctionBody(func.node)).forEach((func) => {
       if (common.isConstantFunction(func.node) !== func.potentiallyshouldBeConst) {
         var funcName = common.getFullQuallyfiedFuncDefinitionIdent(contract.node, func.node, func.parameters)
-        var comments = (hasModifiers) ? '<br/><i>Note:</i> Modifiers are currently not considered by this static analysis.' : ''
-        comments += (multipleContractsWithSameName) ? '<br/><i>Note:</i> Import aliases are currently not supported by this static analysis.' : ''
+        var comments = (hasModifiers) ? 'Note: Modifiers are currently not considered by this static analysis.' : ''
+        comments += (multipleContractsWithSameName) ? 'Note: Import aliases are currently not supported by this static analysis.' : ''
         if (func.potentiallyshouldBeConst) {
           warnings.push({
             warning: `${funcName} : Potentially should be constant but is not. ${comments}`,
@@ -87,7 +88,8 @@ function isConstBreaker (node, context) {
         common.isCallToNonConstLocalFunction(node) ||
         common.isInlineAssembly(node) ||
         common.isNewExpression(node) ||
-        common.isSelfdestructCall(node)
+        common.isSelfdestructCall(node) ||
+        common.isDeleteUnaryOperation(node)
 }
 
 function isCallOnNonConstExternalInterfaceFunction (node, context) {

--- a/remix-solidity/src/analysis/modules/deleteDynamicArrays.js
+++ b/remix-solidity/src/analysis/modules/deleteDynamicArrays.js
@@ -1,0 +1,29 @@
+var name = 'Delete on dynamic Array: '
+var desc = 'Use require and appropriately'
+var categories = require('./categories')
+var common = require('./staticAnalysisCommon')
+
+function deleteDynamicArrays () {
+  this.rel = []
+}
+
+deleteDynamicArrays.prototype.visit = function (node) {
+  if (common.isDeleteOfDynamicArray(node)) this.rel.push(node)
+}
+
+deleteDynamicArrays.prototype.report = function (compilationResults) {
+  return this.rel.map((node) => {
+    return {
+      warning: 'The “delete” operation when applied to a dynamically sized array in Solidity generates code to delete each of the elements contained. If the array is large, this operation can surpass the block gas limit and raise an OOG exception. Also nested dynamically sized objects can produce the same results.',
+      location: node.src,
+      more: 'http://solidity.readthedocs.io/en/latest/types.html?highlight=array#delete'
+    }
+  })
+}
+
+module.exports = {
+  name: name,
+  description: desc,
+  category: categories.GAS,
+  Module: deleteDynamicArrays
+}

--- a/remix-solidity/src/analysis/modules/guardConditions.js
+++ b/remix-solidity/src/analysis/modules/guardConditions.js
@@ -14,7 +14,7 @@ guardConditions.prototype.visit = function (node) {
 guardConditions.prototype.report = function (compilationResults) {
   if (this.guards.length > 0) {
     return [{
-      warning: 'Use <i>assert(x)</i> if you never ever want <i>x</i> to be false, not in any circumstance (apart from a bug in your code). Use <i>require(x)</i> if <i>x</i> can be false, due to e.g. invalid input or a failing external component.',
+      warning: 'Use assert(x) if you never ever want x to be false, not in any circumstance (apart from a bug in your code). Use require(x) if x can be false, due to e.g. invalid input or a failing external component.',
       more: 'http://solidity.readthedocs.io/en/develop/control-structures.html#error-handling-assert-require-revert-and-exceptions'
     }]
   }

--- a/remix-solidity/src/analysis/modules/list.js
+++ b/remix-solidity/src/analysis/modules/list.js
@@ -11,5 +11,6 @@ module.exports = [
   require('./blockBlockhash'),
   require('./noReturn'),
   require('./selfdestruct'),
-  require('./guardConditions')
+  require('./guardConditions'),
+  require('./deleteDynamicArrays')
 ]

--- a/remix-solidity/src/analysis/modules/similarVariableNames.js
+++ b/remix-solidity/src/analysis/modules/similarVariableNames.js
@@ -4,6 +4,8 @@ var categories = require('./categories')
 var common = require('./staticAnalysisCommon')
 var AbstractAst = require('./abstractAstView')
 var levenshtein = require('fast-levenshtein')
+var remixLib = require('remix-lib')
+var util = remixLib.util
 
 function similarVariableNames () {
   this.abstractAst = new AbstractAst()
@@ -53,7 +55,7 @@ function findSimilarVarNames (vars) {
   var similar = []
   var comb = {}
   vars.map((varName1) => vars.map((varName2) => {
-    if (varName1.length > 1 && varName2.length > 1 && varName2 !== varName1 && !isCommonPrefixedVersion(varName1, varName2) && !(comb[varName1 + ';' + varName2] || comb[varName2 + ';' + varName1])) {
+    if (varName1.length > 1 && varName2.length > 1 && varName2 !== varName1 && !isCommonPrefixedVersion(varName1, varName2) && !isCommonNrSuffixVersion(varName1, varName2) && !(comb[varName1 + ';' + varName2] || comb[varName2 + ';' + varName1])) {
       comb[varName1 + ';' + varName2] = true
       var distance = levenshtein.get(varName1, varName2)
       if (distance <= 2) similar.push({ var1: varName1, var2: varName2, distance: distance })
@@ -64,6 +66,12 @@ function findSimilarVarNames (vars) {
 
 function isCommonPrefixedVersion (varName1, varName2) {
   return (varName1.startsWith('_') && varName1.slice(1) === varName2) || (varName2.startsWith('_') && varName2.slice(1) === varName1)
+}
+
+function isCommonNrSuffixVersion (varName1, varName2) {
+  var ref = '^' + util.escapeRegExp(varName1.slice(0, -1)) + '[0-9]$'
+
+  return varName2.match(ref) != null
 }
 
 function getFunctionVariables (contract, func) {

--- a/remix-solidity/src/analysis/modules/similarVariableNames.js
+++ b/remix-solidity/src/analysis/modules/similarVariableNames.js
@@ -69,7 +69,7 @@ function isCommonPrefixedVersion (varName1, varName2) {
 }
 
 function isCommonNrSuffixVersion (varName1, varName2) {
-  var ref = '^' + util.escapeRegExp(varName1.slice(0, -1)) + '[0-9]$'
+  var ref = '^' + util.escapeRegExp(varName1.slice(0, -1)) + '[0-9]*$'
 
   return varName2.match(ref) != null
 }

--- a/remix-solidity/src/analysis/modules/staticAnalysisCommon.js
+++ b/remix-solidity/src/analysis/modules/staticAnalysisCommon.js
@@ -27,7 +27,10 @@ var basicTypes = {
   UINT: 'uint256',
   BOOL: 'bool',
   ADDRESS: 'address',
-  BYTES32: 'bytes32'
+  BYTES32: 'bytes32',
+  STRING_MEM: 'string memory',
+  BYTES_MEM: 'bytes memory',
+  BYTES4: 'bytes4'
 }
 
 var basicRegex = {
@@ -57,10 +60,10 @@ var builtinFunctions = {
   'mulmod(uint256,uint256,uint256)': true,
   'selfdestruct(address)': true,
   'revert()': true,
+  'revert(string memory)': true,
   'assert(bool)': true,
   'require(bool)': true,
   'require(bool,string memory)': true,
-  'revert(string memory)': true,
   'gasleft()': true,
   'blockhash(uint)': true
 }
@@ -79,6 +82,29 @@ var specialVariables = {
     obj: 'block',
     member: 'blockhash',
     type: buildFunctionSignature([basicTypes.UINT], [basicTypes.BYTES32], false)
+  }
+}
+
+var abiNamespace = {
+  ENCODE: {
+    obj: 'abi',
+    member: 'encode',
+    type: buildFunctionSignature([], [basicTypes.BYTES_MEM], false, 'pure')
+  },
+  ENCODEPACKED: {
+    obj: 'abi',
+    member: 'encodePacked',
+    type: buildFunctionSignature([], [basicTypes.BYTES_MEM], false, 'pure')
+  },
+  ENCODE_SELECT: {
+    obj: 'abi',
+    member: 'encodeWithSelector',
+    type: buildFunctionSignature([basicTypes.BYTES4], [basicTypes.BYTES_MEM], false, 'pure')
+  },
+  ENCODE_SIG: {
+    obj: 'abi',
+    member: 'encodeWithSignature',
+    type: buildFunctionSignature([basicTypes.STRING_MEM], [basicTypes.BYTES_MEM], false, 'pure')
   }
 }
 
@@ -441,7 +467,16 @@ function isLocalCallGraphRelevantNode (node) {
  * @return {bool}
  */
 function isBuiltinFunctionCall (node) {
-  return isLocalCall(node) && builtinFunctions[getLocalCallName(node) + '(' + getFunctionCallTypeParameterType(node) + ')'] === true
+  return (isLocalCall(node) && builtinFunctions[getLocalCallName(node) + '(' + getFunctionCallTypeParameterType(node) + ')'] === true) || isAbiNamespaceCall(node)
+}
+
+/**
+ * True if is builtin function like assert, sha3, erecover, ...
+ * @node {ASTNode} some AstNode
+ * @return {bool}
+ */
+function isAbiNamespaceCall (node) {
+  return Object.keys(abiNamespace).some((key) => abiNamespace.hasOwnProperty(key) && node.children && node.children[0] && isSpecialVariableAccess(node.children[0], abiNamespace[key]))
 }
 
 /**
@@ -809,8 +844,8 @@ function exactMatch (regexStr) {
  *  list of return type names
  * @return {Boolean} isPayable
  */
-function buildFunctionSignature (paramTypes, returnTypes, isPayable) {
-  return 'function (' + util.concatWithSeperator(paramTypes, ',') + ')' + ((isPayable) ? ' payable' : '') + ((returnTypes.length) ? ' returns (' + util.concatWithSeperator(returnTypes, ',') + ')' : '')
+function buildFunctionSignature (paramTypes, returnTypes, isPayable, additionalMods) {
+  return 'function (' + util.concatWithSeperator(paramTypes, ',') + ')' + ((isPayable) ? ' payable' : '') + ((additionalMods) ? ' ' + additionalMods : '') + ((returnTypes.length) ? ' returns (' + util.concatWithSeperator(returnTypes, ',') + ')' : '')
 }
 
 /**
@@ -859,6 +894,8 @@ module.exports = {
 
   // #################### Complex Node Identification
   isDeleteOfDynamicArray: isDeleteOfDynamicArray,
+  isAbiNamespaceCall: isAbiNamespaceCall,
+  isSpecialVariableAccess: isSpecialVariableAccess,
   isDynamicArrayAccess: isDynamicArrayAccess,
   hasFunctionBody: hasFunctionBody,
   isInteraction: isInteraction,

--- a/remix-solidity/test/analysis/staticAnalysisCommon-test.js
+++ b/remix-solidity/test/analysis/staticAnalysisCommon-test.js
@@ -2094,3 +2094,19 @@ test('staticAnalysisCommon: function call with of function with function paramet
 
   t.equals(common.getFunctionCallTypeParameterType(node1), 'function (uint256,uint256) pure returns (uint256),uint256,uint256', 'Extracts param right type')
 })
+
+test('staticAnalysisCommon: require call', function (t) {
+  t.plan(3)
+  var node = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'isStructConstructorCall': false, 'lValueRequested': false, 'names': [null], 'type': 'tuple()', 'type_conversion': false}, 'children': [{'attributes': {'argumentTypes': [{'typeIdentifier': 't_bool', 'typeString': 'bool'}, {'typeIdentifier': 't_stringliteral_80efd193f332877914d93edb0b3ef5c6a7eecd00c6251c3fd7f146b60b40e6cd', 'typeString': 'literal_string \'fuu\''}], 'overloadedDeclarations': [90, 91], 'referencedDeclaration': 91, 'type': 'function (bool,string memory) pure', 'value': 'require'}, 'id': 50, 'name': 'Identifier', 'src': '462:7:0'}, {'attributes': {'argumentTypes': null, 'commonType': {'typeIdentifier': 't_address', 'typeString': 'address'}, 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'operator': '==', 'type': 'bool'}, 'children': [{'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'member_name': 'sender', 'referencedDeclaration': null, 'type': 'address'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 87, 'type': 'msg', 'value': 'msg'}, 'id': 51, 'name': 'Identifier', 'src': '470:3:0'}], 'id': 52, 'name': 'MemberAccess', 'src': '470:10:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 10, 'type': 'address', 'value': 'owner'}, 'id': 53, 'name': 'Identifier', 'src': '484:5:0'}], 'id': 54, 'name': 'BinaryOperation', 'src': '470:19:0'}, {'attributes': {'argumentTypes': null, 'hexvalue': '667575', 'isConstant': false, 'isLValue': false, 'isPure': true, 'lValueRequested': false, 'subdenomination': null, 'token': 'string', 'type': 'literal_string \'fuu\'', 'value': 'fuu'}, 'id': 55, 'name': 'Literal', 'src': '491:5:0'}], 'id': 56, 'name': 'FunctionCall', 'src': '462:35:0'}
+
+  t.equals(common.isRequireCall(node), true)
+  t.equals(common.getFunctionCallType(node), 'function (bool,string memory) pure', 'Extracts right type')
+  t.equals(common.getFunctionCallTypeParameterType(node), 'bool,string memory', 'Extracts param right type')
+})
+
+test('staticAnalysisCommon: isDeleteOfDynamicArray', function (t) {
+  t.plan(2)
+  var node = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'operator': 'delete', 'prefix': true, 'type': 'tuple()'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 4, 'type': 'uint256[] storage ref', 'value': 'users'}, 'id': 58, 'name': 'Identifier', 'src': '514:5:0'}], 'id': 59, 'name': 'UnaryOperation', 'src': '507:12:0'}
+  t.equals(common.isDeleteOfDynamicArray(node), true)
+  t.equals(common.isDynamicArrayAccess(node.children[0]), true, 'Extracts right type')
+})

--- a/remix-solidity/test/analysis/staticAnalysisCommon-test.js
+++ b/remix-solidity/test/analysis/staticAnalysisCommon-test.js
@@ -7,11 +7,19 @@ function escapeRegExp (str) {
 }
 
 test('staticAnalysisCommon.helpers.buildFunctionSignature', function (t) {
-  t.plan(7)
+  t.plan(9)
 
   t.equal(common.helpers.buildFunctionSignature([common.basicTypes.UINT, common.basicTypes.ADDRESS], [common.basicTypes.BOOL], false),
     'function (uint256,address) returns (bool)',
     'two params and return value without payable')
+
+  t.equal(common.helpers.buildFunctionSignature([common.basicTypes.UINT, common.basicTypes.ADDRESS], [common.basicTypes.BOOL], false, 'pure'),
+    'function (uint256,address) pure returns (bool)',
+    'two params and return value without payable but pure')
+
+  t.equal(common.helpers.buildFunctionSignature([common.basicTypes.UINT, common.basicTypes.ADDRESS], [common.basicTypes.BOOL], true, 'pure'),
+    'function (uint256,address) payable pure returns (bool)',
+    'two params and return value without payable but pure')
 
   t.equal(common.helpers.buildFunctionSignature([common.basicTypes.UINT, common.basicTypes.BYTES32, common.basicTypes.BYTES32], [], true),
     'function (uint256,bytes32,bytes32) payable',
@@ -2109,4 +2117,22 @@ test('staticAnalysisCommon: isDeleteOfDynamicArray', function (t) {
   var node = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'operator': 'delete', 'prefix': true, 'type': 'tuple()'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 4, 'type': 'uint256[] storage ref', 'value': 'users'}, 'id': 58, 'name': 'Identifier', 'src': '514:5:0'}], 'id': 59, 'name': 'UnaryOperation', 'src': '507:12:0'}
   t.equals(common.isDeleteOfDynamicArray(node), true)
   t.equals(common.isDynamicArrayAccess(node.children[0]), true, 'Extracts right type')
+})
+
+test('staticAnalysisCommon: isAbiNamespaceCall', function (t) {
+  t.plan(8)
+  var node1 = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'isStructConstructorCall': false, 'lValueRequested': false, 'names': [null], 'type': 'bytes memory', 'type_conversion': false}, 'children': [{'attributes': {'argumentTypes': [{'typeIdentifier': 't_uint256', 'typeString': 'uint256'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}], 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'member_name': 'encode', 'referencedDeclaration': null, 'type': 'function () pure returns (bytes memory)'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 64, 'type': 'abi', 'value': 'abi'}, 'id': 26, 'name': 'Identifier', 'src': '245: 3:0'}], 'id': 28, 'name': 'MemberAccess', 'src': '245:10:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 7, 'type': 'uint256', 'value': 'a'}, 'id': 29, 'name': 'Identifier', 'src': '256:1:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 15, 'type': 'uint256', 'value': 'b'}, 'id': 30, 'name': 'Identifier', 'src': '258:1:0'}], 'id': 31, 'name': 'FunctionCall', 'src': '245:15:0'}
+  var node2 = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'isStructConstructorCall': false, 'lValueRequested': false, 'names': [null], 'type': 'bytes memory', 'type_conversion': false}, 'children': [{'attributes': {'argumentTypes': [{'typeIdentifier': 't_uint256', 'typeString': 'uint256'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}], 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'member_name': 'encodePacked', 'referencedDeclaration': null, 'type': 'function () pure returns (bytes memory)'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 64, 'type': 'abi', 'value': 'abi'}, 'id': 33, 'name': 'Identifier', 'src': '279:3:0'}], 'id': 35, 'name': 'MemberAccess', 'src': '279:16:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 7, 'type': 'uint256', 'value': 'a'}, 'id': 36, 'name': 'Identifier', 'src': '296:1:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 15, 'type': 'uint256', 'value': 'b'}, 'id': 37, 'name': 'Identifier', 'src': '298:1:0'}], 'id': 38, 'name': 'FunctionCall', 'src': '279:21:0'}
+  var node3 = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'isStructConstructorCall': false, 'lValueRequested': false, 'names': [null], 'type': 'bytes memory', 'type_conversion': false}, 'children': [{'attributes': {'argumentTypes': [{'typeIdentifier': 't_bytes4', 'typeString': 'bytes4'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}], 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'member_name': 'encodeWithSelector', 'referencedDeclaration': null, 'type': 'function (bytes4) pure returns (bytes memory)'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 64, 'type': 'abi', 'value': 'abi'}, 'id': 40, 'name': 'Identifier', 'src': '319:3:0'}], 'id': 42, 'name': 'MemberAccess', 'src': '319:22:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 19, 'type': 'bytes4', 'value': 'selector'}, 'id': 43, 'name': 'Identifier', 'src': '342:8:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 7, 'type': 'uint256', 'value': 'a'}, 'id': 44, 'name': 'Identifier', 'src': '352:1:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 15, 'type': 'uint256', 'value': 'b'}, 'id': 45, 'name': 'Identifier', 'src': '355:1:0'}], 'id': 46, 'name': 'FunctionCall', 'src': '319:38:0'}
+  var node4 = {'attributes': {'argumentTypes': null, 'isConstant': false, 'isLValue': false, 'isPure': false, 'isStructConstructorCall': false, 'lValueRequested': false, 'names': [null], 'type': 'bytes memory', 'type_conversion': false}, 'children': [{'attributes': {'argumentTypes': [{'typeIdentifier': 't_string_memory_ptr', 'typeString': 'string memory'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}, {'typeIdentifier': 't_uint256', 'typeString': 'uint256'}], 'isConstant': false, 'isLValue': false, 'isPure': false, 'lValueRequested': false, 'member_name': 'encodeWithSignature', 'referencedDeclaration': null, 'type': 'function (string memory) pure returns (bytes memory)'}, 'children': [{'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 64, 'type': 'abi', 'value': 'abi'}, 'id': 48, 'name': 'Identifier', 'src': '367:3:0'}], 'id': 50, 'name': 'MemberAccess', 'src': '367:23:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 11, 'type': 'string memory', 'value': 'sig'}, 'id': 51, 'name': 'Identifier', 'src': '391:3:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 7, 'type': 'uint256', 'value': 'a'}, 'id': 52, 'name': 'Identifier', 'src': '396:1:0'}, {'attributes': {'argumentTypes': null, 'overloadedDeclarations': [null], 'referencedDeclaration': 15, 'type': 'uint256', 'value': 'b'}, 'id': 53, 'name': 'Identifier', 'src': '399:1:0'}], 'id': 54, 'name': 'FunctionCall', 'src': '367:34:0'}
+
+  t.equals(common.isAbiNamespaceCall(node1), true, 'encode abi')
+  t.equals(common.isAbiNamespaceCall(node2), true, 'encodePacked abi')
+  t.equals(common.isAbiNamespaceCall(node3), true, 'encodeWithSelector abi')
+  t.equals(common.isAbiNamespaceCall(node4), true, 'encodeWithSignature abi')
+
+  t.equals(common.isBuiltinFunctionCall(node1), true, 'encode Builtin')
+  t.equals(common.isBuiltinFunctionCall(node2), true, 'encodePacked Builtin')
+  t.equals(common.isBuiltinFunctionCall(node3), true, 'encodeWithSelector Builtin')
+  t.equals(common.isBuiltinFunctionCall(node4), true, 'encodeWithSignature Builtin')
 })

--- a/remix-solidity/test/analysis/staticAnalysisIntegration-test.js
+++ b/remix-solidity/test/analysis/staticAnalysisIntegration-test.js
@@ -27,7 +27,8 @@ var testFiles = [
   'transfer.sol',
   'ctor.sol',
   'forgottenReturn.sol',
-  'selfdestruct.sol'
+  'selfdestruct.sol',
+  'deleteDynamicArray.sol'
 ]
 
 var testFileAsts = {}
@@ -60,7 +61,8 @@ test('Integration test thisLocal.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -91,7 +93,8 @@ test('Integration test checksEffectsInteraction.js', function (t) {
     'transfer.sol': 1,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -122,7 +125,8 @@ test('Integration test constantFunctions.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 1
+    'selfdestruct.sol': 1,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -153,7 +157,8 @@ test('Integration test inlineAssembly.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -184,7 +189,8 @@ test('Integration test txOrigin.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -215,7 +221,8 @@ test('Integration test gasCosts.js', function (t) {
     'transfer.sol': 1,
     'ctor.sol': 0,
     'forgottenReturn.sol': 3,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 2
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -246,7 +253,8 @@ test('Integration test similarVariableNames.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 1,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 1
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -277,7 +285,8 @@ test('Integration test inlineAssembly.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -308,7 +317,8 @@ test('Integration test blockTimestamp.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -339,7 +349,8 @@ test('Integration test lowLevelCalls.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -370,7 +381,8 @@ test('Integration test blockBlockhash.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -401,7 +413,8 @@ test('Integration test noReturn.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 1,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -432,7 +445,8 @@ test('Integration test selfdestruct.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 2
+    'selfdestruct.sol': 2,
+    'deleteDynamicArray.sol': 0
   }
 
   runModuleOnFiles(module, t, (file, report) => {
@@ -463,11 +477,44 @@ test('Integration test guardConditions.js', function (t) {
     'transfer.sol': 0,
     'ctor.sol': 0,
     'forgottenReturn.sol': 0,
-    'selfdestruct.sol': 0
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 1
   }
 
   runModuleOnFiles(module, t, (file, report) => {
     t.equal(report.length, lengthCheck[file], `${file} has right amount of guardCondition warnings`)
+  })
+})
+
+test('Integration test deleteDynamicArrays.js', function (t) {
+  t.plan(testFiles.length)
+
+  var module = require('../../src/analysis/modules/deleteDynamicArrays')
+
+  var lengthCheck = {
+    'KingOfTheEtherThrone.sol': 0,
+    'assembly.sol': 0,
+    'ballot.sol': 0,
+    'ballot_reentrant.sol': 0,
+    'ballot_withoutWarnings.sol': 0,
+    'cross_contract.sol': 0,
+    'inheritance.sol': 0,
+    'modifier1.sol': 0,
+    'modifier2.sol': 0,
+    'notReentrant.sol': 0,
+    'structReentrant.sol': 0,
+    'thisLocal.sol': 0,
+    'globals.sol': 0,
+    'library.sol': 0,
+    'transfer.sol': 0,
+    'ctor.sol': 0,
+    'forgottenReturn.sol': 0,
+    'selfdestruct.sol': 0,
+    'deleteDynamicArray.sol': 2
+  }
+
+  runModuleOnFiles(module, t, (file, report) => {
+    t.equal(report.length, lengthCheck[file], `${file} has right amount of deleteDynamicArrays warnings`)
   })
 })
 

--- a/remix-solidity/test/analysis/test-contracts/deleteDynamicArray.sol
+++ b/remix-solidity/test/analysis/test-contracts/deleteDynamicArray.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.4.22;
+contract arr {
+    uint[] users;
+    
+    bytes access_rights_per_user;
+    
+    uint user_index;
+     
+    address owner;
+    
+    string grr = "message";
+    
+    uint[100] last_100_users;
+    
+    constructor(address owner1) public {
+       owner = owner1;
+       user_index = 0;
+    }
+    
+    function addUser(uint id, byte rights) public{
+        users[user_index] = id;
+        last_100_users[user_index % 100] = id;
+        access_rights_per_user[user_index] = rights;
+        user_index++;
+    }
+    
+    function resetState() public{
+        require(msg.sender == owner, grr);
+        delete users;
+        delete access_rights_per_user;
+        delete last_100_users;
+    }  
+    
+    function bla(string bal) public {
+        grr = bal;
+    }
+}


### PR DESCRIPTION
…low number prefix, add delete dynamic array module

Added a first implementation as discussed here: https://github.com/ethereum/solidity/issues/3324



Minor fixes:
- Removed html from all warnings since remix does not yoyofiy (parse) them anymore. Fixed #768.
- constantFunction module: add delete unary keyword to the evaluation  (changes state)
- similarNames module: allow variables with nr suffix without warning ("var1", "var8" are now not considered to similar)