### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Remix also supports testing, debugging and deploying of smart contracts and much
 Our Remix project with all its features is available
 at `remix.ethereum.org <http://remix.ethereum.org>`__ and more information can be found in these
 docs.  Our tool is available at `our GitHub repository
-<https://github.com/ethereum/remix>`__.
+<https://github.com/ethereum/remix-ide>`__.
 
 This set of documents covers instructions on how to use Remix and some tutorials to help you get started.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Remix also supports testing, debugging and deploying of smart contracts and much
 Our Remix project with all its features is available
 at `remix.ethereum.org <http://remix.ethereum.org>`__ and more information can be found in these
 docs.  Our tool is available at `our GitHub repository
-<https://github.com/ethereum/remix-id>`__.
+<https://github.com/ethereum/remix>`__.
 
 This set of documents covers instructions on how to use Remix and some tutorials to help you get started.
 


### PR DESCRIPTION
Repo link fix: as this is a Remix docs file, sounds like the repo should be listed as "github.com/ethereum/**remix**" (not "github.com/ethereum/**remix-id**" as it is now, and not "github.com/ethereum/**remix-ide**" which would point to the IDE)