### PR TITLE
Import fix, winston logger, intro message

### DIFF
--- a/remix-analyzer/package.json
+++ b/remix-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-analyzer",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Remix Analyzer",
   "main": "./index.js",
   "contributors": [
@@ -21,7 +21,7 @@
     "babel-eslint": "^7.1.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.24.0",
-    "remix-lib": "^0.3.6",
+    "remix-lib": "^0.3.7",
     "solc": "^0.4.24",
     "standard": "^7.0.1",
     "tape": "^4.6.0"

--- a/remix-debug/package.json
+++ b/remix-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-debug",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Ethereum IDE and tools for the web",
   "contributors": [
     {
@@ -23,7 +23,7 @@
     "fast-async": "^6.1.2",
     "notify-error": "^1.2.0",
     "npm-run-all": "^4.1.2",
-    "remix-lib": "^0.3.6",
+    "remix-lib": "^0.3.7",
     "solc": "^0.4.24"
   },
   "devDependencies": {

--- a/remix-lib/package.json
+++ b/remix-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-lib",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Ethereum IDE and tools for the web",
   "contributors": [
     {

--- a/remix-lib/src/execution/txRunner.js
+++ b/remix-lib/src/execution/txRunner.js
@@ -135,7 +135,7 @@ TxRunner.prototype.runInNode = function (from, to, data, value, gasLimit, useCal
     return executionContext.web3().eth.call(tx, function (error, result) {
       callback(error, {
         result: result,
-        transactionHash: result.transactionHash
+        transactionHash: result ? result.transactionHash : null
       })
     })
   }
@@ -187,7 +187,7 @@ function tryTillResponse (txhash, done) {
     } else {
       done(err, {
         result: result,
-        transactionHash: result.transactionHash
+        transactionHash: result ? result.transactionHash : null
       })
     }
   })

--- a/remix-solidity/package.json
+++ b/remix-solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-solidity",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Ethereum IDE and tools for the web",
   "contributors": [
     {
@@ -22,7 +22,7 @@
     "ethereumjs-vm": "^2.3.3",
     "fast-async": "^6.1.2",
     "npm-run-all": "^4.0.2",
-    "remix-lib": "^0.3.6",
+    "remix-lib": "^0.3.7",
     "solc": "^0.4.24",
     "standard": "^7.0.1",
     "tape": "^4.6.0",

--- a/remix-tests/examples/simple_storage2_test.sol
+++ b/remix-tests/examples/simple_storage2_test.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.7;
+import "remix_test.sol";
 import "./simple_storage.sol";
 
 contract MyTest2 {

--- a/remix-tests/examples/simple_storage2_test.sol
+++ b/remix-tests/examples/simple_storage2_test.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.4.7;
-import "./tests.sol";
 import "./simple_storage.sol";
 
 contract MyTest2 {
@@ -26,4 +25,3 @@ contract MyTest2 {
   }
 
 }
-

--- a/remix-tests/examples/simple_storage_test.sol
+++ b/remix-tests/examples/simple_storage_test.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.4.7;
-import "./tests.sol";
 import "./simple_storage.sol";
 
 contract MyTest {
@@ -26,4 +25,3 @@ contract MyTest {
   }
 
 }
-

--- a/remix-tests/package.json
+++ b/remix-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-tests",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Tests for the Ethereum tool suite Remix",
   "main": "./src/index.js",
   "contributors": [
@@ -42,7 +42,7 @@
     "colors": "^1.1.2",
     "commander": "^2.13.0",
     "remix-simulator": "0.0.3",
-    "remix-solidity": "^0.2.6",
+    "remix-solidity": "^0.2.7",
     "solc": "^0.4.24",
     "standard": "^10.0.3",
     "web3": "1.0.0-beta.27"

--- a/remix-tests/package.json
+++ b/remix-tests/package.json
@@ -46,7 +46,8 @@
     "signale": "^1.2.1",
     "solc": "^0.4.24",
     "standard": "^10.0.3",
-    "web3": "1.0.0-beta.27"
+    "web3": "1.0.0-beta.27",
+    "winston": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^5.1.0"

--- a/remix-tests/package.json
+++ b/remix-tests/package.json
@@ -43,6 +43,7 @@
     "commander": "^2.13.0",
     "remix-simulator": "0.0.3",
     "remix-solidity": "^0.2.7",
+    "signale": "^1.2.1",
     "solc": "^0.4.24",
     "standard": "^10.0.3",
     "web3": "1.0.0-beta.27"

--- a/remix-tests/src/compiler.js
+++ b/remix-tests/src/compiler.js
@@ -1,11 +1,16 @@
+/* eslint no-extend-native: "warn" */
 let fs = require('fs')
 var async = require('async')
 var path = require('path')
 const signale = require('signale')
 let RemixCompiler = require('remix-solidity').Compiler
 
-// TODO: replace this with remix's own compiler code
+String.prototype.regexIndexOf = function (regex, startpos) {
+  var indexOf = this.substring(startpos || 0).search(regex)
+  return (indexOf >= 0) ? (indexOf + (startpos || 0)) : indexOf
+}
 
+// TODO: replace this with remix's own compiler code
 function compileFileOrFiles (filename, isDirectory, cb) {
   let compiler, filepath
 
@@ -23,7 +28,8 @@ function compileFileOrFiles (filename, isDirectory, cb) {
     // only process .sol files
     if (file.split('.').pop() === 'sol') {
       let c = fs.readFileSync(path.join(filepath, file)).toString()
-      if (file.indexOf('_test.sol') > 0) {
+      const s = /^(import)\s['"](remix_tests.sol|tests.sol)['"];/gm
+      if (file.indexOf('_test.sol') > 0 && c.regexIndexOf(s) < 0) {
         c = c.replace(/(pragma solidity \^\d+\.\d+\.\d+;)/, '$1\nimport \'remix_tests.sol\';')
       }
       sources[file] = { content: c }
@@ -58,7 +64,7 @@ function compileContractSources (sources, importFileCb, cb) {
   let compiler, filepath
 
   if (!sources['remix_tests.sol']) {
-    sources['remix_tests.sol'] = {content: require('../sol/tests.sol.js')}
+    sources['remix_tests.sol'] = { content: require('../sol/tests.sol.js') }
   }
 
   async.waterfall([

--- a/remix-tests/src/index.js
+++ b/remix-tests/src/index.js
@@ -1,6 +1,7 @@
 const async = require('async')
 const path = require('path')
 const fs = require('fs')
+const { Signale } = require('signale')
 require('colors')
 
 let Compiler = require('./compiler.js')
@@ -11,10 +12,33 @@ const Web3 = require('web3')
 const Provider = require('remix-simulator').Provider
 
 var createWeb3Provider = function () {
+  signale.info('Creating providers')
   let web3 = new Web3()
   web3.setProvider(new Provider())
   return web3
 }
+
+// signale configuration
+const options = {
+  types: {
+    result: {
+      badge: '\t✓',
+      label: '',
+      color: 'greenBright'
+    },
+    name: {
+      badge: '\n\t◼',
+      label: '',
+      color: 'white'
+    },
+    error: {
+      badge: '\t✘',
+      label: '',
+      color: 'redBright'
+    }
+  }
+}
+const signale = new Signale(options)
 
 var runTestSources = function (contractSources, testCallback, resultCallback, finalCallback, importFileCb) {
   async.waterfall([
@@ -134,11 +158,11 @@ var runTestFiles = function (filepath, isDirectory, web3) {
 
       var testCallback = function (result) {
         if (result.type === 'contract') {
-          console.log('\n  ' + result.value)
+          signale.name(result.value.white)
         } else if (result.type === 'testPass') {
-          console.log('\t✓ '.green.bold + result.value.grey)
+          signale.result(result.value)
         } else if (result.type === 'testFailure') {
-          console.log('\t✘ '.bold.red + result.value.red)
+          signale.result(result.value.red)
           errors.push(result)
         }
       }

--- a/remix-tests/src/index.js
+++ b/remix-tests/src/index.js
@@ -12,7 +12,6 @@ const Web3 = require('web3')
 const Provider = require('remix-simulator').Provider
 
 var createWeb3Provider = function () {
-  signale.info('Creating providers')
   let web3 = new Web3()
   web3.setProvider(new Provider())
   return web3

--- a/remix-tests/src/logger.js
+++ b/remix-tests/src/logger.js
@@ -1,0 +1,58 @@
+var gray = require('ansi-gray')
+const winston = require('winston')
+var timestamp = require('time-stamp')
+var supportsColor = require('color-support')
+
+function hasFlag (flag) {
+  return ((typeof (process) !== 'undefined') && (process.argv.indexOf('--' + flag) !== -1))
+}
+
+function addColor (str) {
+  if (hasFlag('no-color')) {
+    return str
+  }
+
+  if (hasFlag('color')) {
+    return gray(str)
+  }
+
+  if (supportsColor()) {
+    return gray(str)
+  }
+
+  return str
+}
+function getTimestamp () {
+  return '[' + addColor(timestamp('HH:mm:ss')) + ']'
+}
+// create winston logger format
+const logFmt = winston.format.printf((info) => {
+  return `${getTimestamp()} ${info.level}: ${info.message}`
+})
+
+class Log {
+  constructor () {
+    this.logger = winston.createLogger({
+      level: 'error',
+      transports: [new winston.transports.Console()],
+      format: winston.format.combine(
+        winston.format.colorize({ all: true }),
+        logFmt
+      )
+    })
+  }
+  setVerbosity (v) {
+    this.logger.configure({
+      level: v,
+      transports: [new winston.transports.Console()],
+      format: winston.format.combine(
+        winston.format.colorize({ all: true }),
+        logFmt
+      )
+    })
+  }
+}
+
+module.exports = {
+  Log
+}

--- a/remix-tests/src/run.js
+++ b/remix-tests/src/run.js
@@ -2,35 +2,48 @@ const commander = require('commander')
 const Web3 = require('web3')
 const RemixTests = require('./index.js')
 const fs = require('fs')
-const { Signale } = require('signale')
 const Provider = require('remix-simulator').Provider
+const { Log } = require('./logger.js')
+const logger = new Log()
+const log = logger.logger
 require('colors')
 
-// signale configuration
-const options = {
-  types: {
-    greet: {
-      badge: '\n👁',
-      label: '',
-      color: 'yellow'
-    }
+// parse verbosity
+function mapVerbosity (v) {
+  const levels = {
+    0: 'error',
+    1: 'warn',
+    2: 'info',
+    3: 'verbose',
+    4: 'debug',
+    5: 'silly'
   }
+  return levels[v]
 }
-const signale = new Signale(options)
+// get current version
+const pjson = require('../package.json')
+commander
+  .version(pjson.version)
+  .option('-v, --verbose <level>', 'run with verbosity', mapVerbosity)
+  .action(function (filename) {
+    // Console message
+    console.log(('\n\t👁 :: Running remix-tests - Unit testing for solidity :: 👁\t\n').white)
+    // set logger verbosity
+    if (commander.verbose) {
+      logger.setVerbosity(commander.verbose)
+      log.info('verbosity level set to ' + commander.verbose.blue)
+    }
+    let web3 = new Web3()
+    // web3.setProvider(new web3.providers.HttpProvider('http://localhost:8545'))
+    web3.setProvider(new Provider())
+    // web3.setProvider(new web3.providers.WebsocketProvider('ws://localhost:8546'))
 
-commander.action(function (filename) {
-  signale.greet(('Running remix-tests: Unit testing for solidity.\n').yellow)
-  let web3 = new Web3()
-  // web3.setProvider(new web3.providers.HttpProvider('http://localhost:8545'))
-  web3.setProvider(new Provider())
-  // web3.setProvider(new web3.providers.WebsocketProvider('ws://localhost:8546'))
-
-  let isDirectory = fs.lstatSync(filename).isDirectory()
-  RemixTests.runTestFiles(filename, isDirectory, web3)
-})
+    let isDirectory = fs.lstatSync(filename).isDirectory()
+    RemixTests.runTestFiles(filename, isDirectory, web3)
+  })
 
 if (!process.argv.slice(2).length) {
-  signale.fatal('Please specify a filename')
+  log.error('Please specify a filename')
   process.exit()
 }
 

--- a/remix-tests/src/run.js
+++ b/remix-tests/src/run.js
@@ -2,6 +2,7 @@ const commander = require('commander')
 const Web3 = require('web3')
 const RemixTests = require('./index.js')
 const fs = require('fs')
+const signale = require('signale')
 
 const Provider = require('remix-simulator').Provider
 
@@ -16,7 +17,8 @@ commander.action(function (filename) {
 })
 
 if (!process.argv.slice(2).length) {
-  console.log('please specify filename')
+  signale.fatal('Please specify a filename')
+  process.exit()
 }
 
 commander.parse(process.argv)

--- a/remix-tests/src/run.js
+++ b/remix-tests/src/run.js
@@ -2,11 +2,24 @@ const commander = require('commander')
 const Web3 = require('web3')
 const RemixTests = require('./index.js')
 const fs = require('fs')
-const signale = require('signale')
-
+const { Signale } = require('signale')
 const Provider = require('remix-simulator').Provider
+require('colors')
+
+// signale configuration
+const options = {
+  types: {
+    greet: {
+      badge: '\n👁',
+      label: '',
+      color: 'yellow'
+    }
+  }
+}
+const signale = new Signale(options)
 
 commander.action(function (filename) {
+  signale.greet(('Running remix-tests: Unit testing for solidity.\n').yellow)
   let web3 = new Web3()
   // web3.setProvider(new web3.providers.HttpProvider('http://localhost:8545'))
   web3.setProvider(new Provider())

--- a/remix-tests/tests/examples_1/simple_storage_test.sol
+++ b/remix-tests/tests/examples_1/simple_storage_test.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.4.7;
-import "remix_tests.sol";
 import "./simple_storage.sol";
 
 contract MyTest {
@@ -29,4 +28,3 @@ contract MyTest {
   }
 
 }
-

--- a/remix-tests/tests/examples_2/simple_storage_test.sol
+++ b/remix-tests/tests/examples_2/simple_storage_test.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.4.7;
-import "./tests.sol";
 import "./simple_storage.sol";
 
 contract MyTest {
@@ -25,4 +24,3 @@ contract MyTest {
   }
 
 }
-

--- a/remix-tests/tests/examples_3/simple_string_test.sol
+++ b/remix-tests/tests/examples_3/simple_string_test.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.4.7;
-import "./tests.sol";
 import "./simple_string.sol";
 
 contract StringTest {


### PR DESCRIPTION
- use `signale` for logging
- `process.exit()` if filename is not specified
- inject `import 'remix_tests.sol'` statement into `_test.sol` files only if not already imported
- only process `.sol` files
![screenshot from 2018-08-25 02-05-28](https://user-images.githubusercontent.com/13261372/44606667-8092a180-a80b-11e8-9abe-611380567736.png)
