### PR TITLE
patch runTestFiles for injecting import statements, update readme

### DIFF
--- a/remix-tests/README.md
+++ b/remix-tests/README.md
@@ -101,7 +101,7 @@ params:
 * `{ type: 'testPass', value: '<name of testing function>', time: <time taken>, context: '<TestName>'}`
 * `{ type: 'testFailure', value: '<name of testing function>', time: <time taken>, context: '<TestName>', errMsg: '<message in the Assert>' }`
 
-`resultCallback(object)`
+`resultCallback(err, object)`
 * `passingNum` - number of passing tests
 * `failureNum` - number of failing tests
 * `timePassed` - time it took for all the tests to run (in seconds)

--- a/remix-tests/examples/simple_storage2_test.sol
+++ b/remix-tests/examples/simple_storage2_test.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.4.7;
-import "remix_test.sol";
+import "remix_tests.sol";
 import "./simple_storage.sol";
 
 contract MyTest2 {


### PR DESCRIPTION
* `runTestFiles()` is not patched with `inject import statements`. Editors are free to ignore library imports.
* update readme