### PR TITLE
new Buffer is deprecated and unsafe

### DIFF
--- a/remix-debug/test/decoder/localDecoder.js
+++ b/remix-debug/test/decoder/localDecoder.js
@@ -14,7 +14,7 @@ var compilerInput = remixLib.helpers.compiler.compilerInput
 
 tape('solidity', function (t) {
   t.test('local decoder', function (st) {
-    var privateKey = new Buffer('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
+    var privateKey = Buffer.from('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
     var vm = vmCall.initVM(st, privateKey)
     test(st, vm, privateKey)
   })

--- a/remix-debug/test/decoder/stateTests/mapping.js
+++ b/remix-debug/test/decoder/stateTests/mapping.js
@@ -11,7 +11,7 @@ var StorageViewer = require('../../../src/storage/storageViewer')
 
 module.exports = function testMappingStorage (st, cb) {
   var mappingStorage = require('../contracts/mappingStorage')
-  var privateKey = new Buffer('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
+  var privateKey = Buffer.from('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
   var vm = vmCall.initVM(st, privateKey)
   var output = compiler.compileStandardWrapper(compilerInput(mappingStorage.contract))
   output = JSON.parse(output)

--- a/remix-debug/test/decoder/vmCall.js
+++ b/remix-debug/test/decoder/vmCall.js
@@ -12,7 +12,7 @@ function sendTx (vm, from, to, value, data, cb) {
     gasLimit: new BN(3000000, 10),
     to: to,
     value: new BN(value, 10),
-    data: new Buffer(data, 'hex')
+    data: Buffer.from(data, 'hex')
   })
   tx.sign(from.privateKey)
   var block = new Block({

--- a/remix-debug/test/tests.js
+++ b/remix-debug/test/tests.js
@@ -15,7 +15,7 @@ var BreakpointManager = remixLib.code.BreakpointManager
 
 tape('debug contract', function (t) {
   t.plan(12)
-  var privateKey = new Buffer('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
+  var privateKey = Buffer.from('dae9801649ba2d95a21e688b56f77905e5667c44ce868ec83f82e838712a2c7a', 'hex')
   var vm = vmCall.initVM(t, privateKey)
   var output = compiler.compileStandardWrapper(compilerInput(ballot))
   output = JSON.parse(output)

--- a/remix-debug/test/vmCall.js
+++ b/remix-debug/test/vmCall.js
@@ -12,7 +12,7 @@ function sendTx (vm, from, to, value, data, cb) {
     gasLimit: new BN(3000000, 10),
     to: to,
     value: new BN(value, 10),
-    data: new Buffer(data, 'hex')
+    data: Buffer.from(data, 'hex')
   })
   tx.sign(from.privateKey)
   var block = new Block({

--- a/remix-lib/src/code/codeResolver.js
+++ b/remix-lib/src/code/codeResolver.js
@@ -48,7 +48,7 @@ CodeResolver.prototype.cacheExecutingCode = function (address, hexCode) {
 }
 
 CodeResolver.prototype.formatCode = function (hexCode) {
-  var code = codeUtils.nameOpCodes(new Buffer(hexCode.substring(2), 'hex'))
+  var code = codeUtils.nameOpCodes(Buffer.from(hexCode.substring(2), 'hex'))
   return {
     code: code[0],
     instructionsIndexByBytesOffset: code[1]

--- a/remix-lib/src/execution/eventsDecoder.js
+++ b/remix-lib/src/execution/eventsDecoder.js
@@ -42,7 +42,7 @@ class EventsDecoder {
     var abi = new ethers.Interface(contract.abi)
     for (var e in abi.events) {
       var event = abi.events[e]
-      eventABI[ethJSUtil.sha3(new Buffer(event.signature)).toString('hex')] = { event: event.name, inputs: event.inputs, object: event }
+      eventABI[ethJSUtil.sha3(Buffer.from(event.signature)).toString('hex')] = { event: event.name, inputs: event.inputs, object: event }
     }
     return eventABI
   }

--- a/remix-lib/src/execution/txRunner.js
+++ b/remix-lib/src/execution/txRunner.js
@@ -100,7 +100,7 @@ class TxRunner {
       gasLimit: new BN(gasLimit, 10),
       to: to,
       value: new BN(value, 10),
-      data: new Buffer(data.slice(2), 'hex')
+      data: Buffer.from(data.slice(2), 'hex')
     })
     tx.sign(account.privateKey)
 
@@ -133,7 +133,7 @@ class TxRunner {
       }
       callback(err, {
         result: result,
-        transactionHash: ethJSUtil.bufferToHex(new Buffer(tx.hash()))
+        transactionHash: ethJSUtil.bufferToHex(Buffer.from(tx.hash()))
       })
     })
   }


### PR DESCRIPTION
#### What does it do?
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

#### Any helpful background information?
The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: 
* https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
* https://github.com/nodejs/Release#end-of-life-releases