### PR TITLE
Fix statemanager.checkpoint() now needing a callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 npm-debug.log
 lint.xml
 .vscode
+.idea
 test-browser/reports/*
 babelify-src
 docs/_build

--- a/remix-lib/src/execution/execution-context.js
+++ b/remix-lib/src/execution/execution-context.js
@@ -67,7 +67,8 @@ var vm = new EthJSVM({
 vm.stateManager = stateManager
 vm.blockchain = stateManager.blockchain
 vm.trie = stateManager.trie
-vm.stateManager.checkpoint()
+// Not waiting for the callback as we are not relying on the checkpoint
+vm.stateManager.checkpoint(() => {})
 
 var web3VM = new Web3VMProvider()
 web3VM.setVM(vm)
@@ -171,11 +172,12 @@ function ExecutionContext () {
 
     if (context === 'vm') {
       executionContext = context
-      vm.stateManager.revert(function () {
-        vm.stateManager.checkpoint()
+      return vm.stateManager.revert(function () {
+        vm.stateManager.checkpoint(function () {
+          self.event.trigger('contextChanged', ['vm'])
+          cb()
+        })
       })
-      self.event.trigger('contextChanged', ['vm'])
-      return cb()
     }
 
     if (context === 'injected') {


### PR DESCRIPTION
A new version of etherumjs-vm now requires `stateManager.checkpoint()` to use a callback, as you can see here: https://github.com/ethereumjs/ethereumjs-vm/blob/master/lib/stateManager.js#L301

This adds those call backs and makes sure the flow still is respected.

The first callback is empty, as it is not needed to wait for the callback for the rest of the operations (basically exporting).