### PR TITLE
minor fixes

### DIFF
--- a/remix-resolve/package.json
+++ b/remix-resolve/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.1",
   "description": "Solidity import resolver engine",
   "main": "./src/index.js",
-  "bin": {
-    "remix-resolve": "./bin/remix-resolve"
-  },
   "scripts": {
     "build": "tsc",
     "lint": "standard",

--- a/remix-resolve/src/combineSource.js
+++ b/remix-resolve/src/combineSource.js
@@ -30,7 +30,7 @@ const combineSource = async function (rootpath, sources) {
           // sources[fileName].content = sources[fileName].content.replace(importLine, 'import' + extra + ' \'' + response.filename + '\';')
           const regex = /(\.+\/)/g
           subSorce[fn.replace(regex, '')] = { content: response.content }
-          sources = Object.assign(await combineSource(response.rootpath, subSorce), sources)
+          sources = Object.assign(await combineSource(response.fileRoot, subSorce), sources)
         }
       } catch (e) {
         throw e


### PR DESCRIPTION
- removed bin configuration from `package.json`: this package doesn't provide binary file, so it causes errors on installation;
- fixed parameter passed to `combineSource` recurrent call: it's called `fileRoot`, not `rootpath` now.