### PR TITLE
Allow timestamps to be passed when running in VM

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,5 @@
     "publish": "lerna publish",
     "release": "lerna bootstrap; lerna publish;",
     "tag": "gulp; gulp publishTag;"
-  },
-  "dependencies": {
-    "remix-ide": "^0.7.5-local",
-    "remixd": "^0.1.8-alpha.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "publish": "lerna publish",
     "release": "lerna bootstrap; lerna publish;",
     "tag": "gulp; gulp publishTag;"
+  },
+  "dependencies": {
+    "remix-ide": "^0.7.5-local",
+    "remixd": "^0.1.8-alpha.6"
   }
 }

--- a/remix-lib/src/execution/txRunner.js
+++ b/remix-lib/src/execution/txRunner.js
@@ -22,7 +22,11 @@ class TxRunner {
   }
 
   rawRun (args, confirmationCb, gasEstimationForceSend, promptCb, cb) {
-    run(this, args, Date.now(), confirmationCb, gasEstimationForceSend, promptCb, cb)
+    var timestamp = Date.now()
+    if (args.timestamp) {
+       timestamp = args.timestamp
+    }
+    run(this, args, timestamp, confirmationCb, gasEstimationForceSend, promptCb, cb)
   }
 
   _executeTx (tx, gasPrice, api, promptCb, callback) {
@@ -81,20 +85,21 @@ class TxRunner {
       self.runInNode(args.from, args.to, data, args.value, args.gasLimit, args.useCall, confirmationCb, gasEstimationForceSend, promptCb, callback)
     } else {
       try {
-        self.runInVm(args.from, args.to, data, args.value, args.gasLimit, args.useCall, callback)
+        self.runInVm(args.from, args.to, data, args.value, args.gasLimit, args.useCall, args.timestamp, callback)
       } catch (e) {
         callback(e, null)
       }
     }
   }
 
-  runInVm (from, to, data, value, gasLimit, useCall, callback) {
+  runInVm (from, to, data, value, gasLimit, useCall, timestamp, callback) {
     const self = this
     var account = self.vmaccounts[from]
     if (!account) {
       return callback('Invalid account selected')
     }
     var tx = new EthJSTX({
+      timestamp: timestamp,
       nonce: new BN(account.nonce++),
       gasPrice: new BN(1),
       gasLimit: new BN(gasLimit, 10),
@@ -108,7 +113,7 @@ class TxRunner {
     const difficulties = [ new BN('69762765929000', 10), new BN('70762765929000', 10), new BN('71762765929000', 10) ]
     var block = new EthJSBlock({
       header: {
-        timestamp: new Date().getTime() / 1000 | 0,
+        timestamp: timestamp || (new Date().getTime() / 1000 | 0),
         number: self.blockNumber,
         coinbase: coinbases[self.blockNumber % coinbases.length],
         difficulty: difficulties[self.blockNumber % difficulties.length],


### PR DESCRIPTION
This change allows timestamps to be passed to `txRunner.rawRun()`. If a timestamp is present, it overrides the timestamps in the new `tx` and new `block` created in `runInVM`. If a timestamp is not given or if remix is not running in a VM, behavior is unchanged.

My intention is to allow remix-ide to specify the timestamp of transactions launched by the recorder. If, for example, a user wanted to reliably test the effect of some time passing between transactions, this would allow her to specify the timestamp for both transactions from the recorder .json file. 

