### PR TITLE
Allow timestamps to be passed to rawRun

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,5 @@
     "publish": "lerna publish",
     "release": "lerna bootstrap; lerna publish;",
     "tag": "gulp; gulp publishTag;"
-  },
-  "dependencies": {
-    "remix-ide": "^0.7.5-local",
-    "remixd": "^0.1.8-alpha.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "publish": "lerna publish",
     "release": "lerna bootstrap; lerna publish;",
     "tag": "gulp; gulp publishTag;"
+  },
+  "dependencies": {
+    "remix-ide": "^0.7.5-local",
+    "remixd": "^0.1.8-alpha.6"
   }
 }

--- a/remix-lib/src/execution/txRunner.js
+++ b/remix-lib/src/execution/txRunner.js
@@ -24,7 +24,7 @@ class TxRunner {
   rawRun (args, confirmationCb, gasEstimationForceSend, promptCb, cb) {
     var timestamp = Date.now()
     if (args.timestamp) {
-       timestamp = args.timestamp
+      timestamp = args.timestamp
     }
     run(this, args, timestamp, confirmationCb, gasEstimationForceSend, promptCb, cb)
   }

--- a/remix-lib/src/execution/txRunner.js
+++ b/remix-lib/src/execution/txRunner.js
@@ -22,7 +22,11 @@ class TxRunner {
   }
 
   rawRun (args, confirmationCb, gasEstimationForceSend, promptCb, cb) {
-    run(this, args, Date.now(), confirmationCb, gasEstimationForceSend, promptCb, cb)
+    var timestamp = Date.now()
+    if (args.timestamp) {
+       timestamp = args.timestamp
+    }
+    run(this, args, timestamp, confirmationCb, gasEstimationForceSend, promptCb, cb)
   }
 
   _executeTx (tx, gasPrice, api, promptCb, callback) {
@@ -81,20 +85,21 @@ class TxRunner {
       self.runInNode(args.from, args.to, data, args.value, args.gasLimit, args.useCall, confirmationCb, gasEstimationForceSend, promptCb, callback)
     } else {
       try {
-        self.runInVm(args.from, args.to, data, args.value, args.gasLimit, args.useCall, callback)
+        self.runInVm(args.from, args.to, data, args.value, args.gasLimit, args.useCall, args.timestamp, callback)
       } catch (e) {
         callback(e, null)
       }
     }
   }
 
-  runInVm (from, to, data, value, gasLimit, useCall, callback) {
+  runInVm (from, to, data, value, gasLimit, useCall, timestamp, callback) {
     const self = this
     var account = self.vmaccounts[from]
     if (!account) {
       return callback('Invalid account selected')
     }
     var tx = new EthJSTX({
+      timestamp: timestamp,
       nonce: new BN(account.nonce++),
       gasPrice: new BN(1),
       gasLimit: new BN(gasLimit, 10),
@@ -108,7 +113,7 @@ class TxRunner {
     const difficulties = [ new BN('69762765929000', 10), new BN('70762765929000', 10), new BN('71762765929000', 10) ]
     var block = new EthJSBlock({
       header: {
-        timestamp: new Date().getTime() / 1000 | 0,
+        timestamp: timestamp || (new Date().getTime() / 1000 | 0),
         number: self.blockNumber,
         coinbase: coinbases[self.blockNumber % coinbases.length],
         difficulty: difficulties[self.blockNumber % difficulties.length],


### PR DESCRIPTION
In order to allow for testing of contracts sensitive to timestamps from, for example, the remix-ide recorder, this change allows a timestamp passed to rawRun to override the default behavior when running in a VM.

When a timestamp is passed as part of the arguments to txRunner.rawRun, that timestamp is recorded in the new block and new tx during runInVM. If no timestamp is provided, behavior is unchanged and the timestamp is taken from Date.now().

This will allow us to create test cases for contracts which are sensitive to the relative or absolute timestamp of particular transactions. I'm attaching a .json file from the recorder in remix-ide. Following this change and another in remix-ide, it will record in the contract, the time it was run *originally*, not the time that the .json was played back.

Some applications of this are a certain behavior that changes after a specific date or a contract that charges time-based interest. 