### PR TITLE
Remove duplicated function declaration 'Ethdebugger.prototype.debug'

### DIFF
--- a/remix-debug/src/Ethdebugger.js
+++ b/remix-debug/src/Ethdebugger.js
@@ -160,15 +160,6 @@ Ethdebugger.prototype.updateWeb3 = function (web3) {
   this.setManagers()
 }
 
-Ethdebugger.prototype.debug = function (tx) {
-  this.setCompilationResult(this.opts.compilationResult())
-  if (tx instanceof Object) {
-    this.txBrowser.load(tx.hash)
-  } else if (tx instanceof String) {
-    this.txBrowser.load(tx)
-  }
-}
-
 Ethdebugger.prototype.unLoad = function () {
   this.traceManager.init()
   this.codeManager.clear()


### PR DESCRIPTION
There is dupliacted function declaration, `Ethdebugger.prototype.debug` in "Ethdebugger.js" file.

First one: 
```js
Ethdebugger.prototype.debug = function (tx) {
  this.setCompilationResult(this.opts.compilationResult())
  if (tx instanceof Object) {
    this.txBrowser.load(tx.hash)
  } else if (tx instanceof String) {
    this.txBrowser.load(tx)
  }
}
```

Second one: 
```js
Ethdebugger.prototype.debug = function (tx) {
  if (this.traceManager.isLoading) {
    return
  }
  if (!tx.to) {
    tx.to = traceHelper.contractCreationToken('0')
  }
  this.setCompilationResult(this.opts.compilationResult())
  this.tx = tx
  var self = this
  this.traceManager.resolveTrace(tx, function (error, result) {
    if (result) {
      self.event.trigger('newTraceLoaded', [self.traceManager.trace])
      if (self.breakpointManager && self.breakpointManager.hasBreakpoint()) {
        self.breakpointManager.jumpNextBreakpoint(false)
      }
      self.storageResolver = new StorageResolver({web3: self.traceManager.web3})
    } else {
      self.statusMessage = error ? error.message : 'Trace not loaded'
    }
  })
}
```

It seems only second one is used currently, so that it would be ok to remove first one.
