### PR TITLE
fix for electron w/dynamic loading of solcjson

### DIFF
--- a/remix-solidity/src/compiler/compiler.js
+++ b/remix-solidity/src/compiler/compiler.js
@@ -74,7 +74,7 @@ function Compiler (handleImportCall) {
     if (worker === null) {
       var compiler
       var userAgent = (typeof (navigator) !== 'undefined') && navigator.userAgent ? navigator.userAgent.toLowerCase() : '-'
-      if (typeof (window) === 'undefined' || userAgent.indexOf(' electron/') > -1) {
+      if (typeof (window) === 'undefined') {
         compiler = require('solc')
       } else {
         compiler = solc(window.Module)


### PR DESCRIPTION
This is a fix so that remix will work inside of electron, and presumably, it makes sense for dynamic downloading of solidity compiler. When I enable node integration with electron and install solc node module, it looks like it works for a second, but then it too does not work (page goes blank).

I'm not sure if require() works here with node, as I believe solcjson would need to be downloaded into a path that can be resolved by require (typically node_modules). Notably, electron docs recommend against enabling node integration when remote scripts are loaded dynamically.

cc @yann300 @pkieltyka