### PR TITLE
remix-debug depends on web3

### DIFF
--- a/remix-debug/package.json
+++ b/remix-debug/package.json
@@ -22,7 +22,8 @@
     "ethereumjs-util": "^4.5.0",
     "ethereumjs-vm": "3.0.0",
     "fast-async": "^6.1.2",
-    "remix-lib": "0.4.5"
+    "remix-lib": "0.4.5",
+    "web3": "0.20.6"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
remix-debug has the following line in `src/cmdline/index.js`:
```
var Web3 = require('web3')

<... snip ...>

  connect (providerType, url) {
    if (providerType !== 'http') throw new Error('unsupported provider type')
    this.web3 = new Web3(new Web3.providers.HttpProvider(url))
  }

```

So it should either mark `web3` as a dependency in `package.json` or
refactor `remix-lib` to provide a web3 provider that can take an
`url` paramter.

This patch does the former and makes `remix-debug` depend on the same
version of `web3` as `remix-lib` in `package.json`.