### PR TITLE
remix-solidity: add compiler.setEvmVersion()

### DIFF
--- a/remix-solidity/src/compiler/compiler-input.js
+++ b/remix-solidity/src/compiler/compiler-input.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = (sources, opts) => {
-  return JSON.stringify({
+  const o = {
     language: 'Solidity',
     sources: sources,
     settings: {
@@ -17,5 +17,9 @@ module.exports = (sources, opts) => {
         }
       }
     }
-  })
+  }
+  if (opts.evmVersion) {
+    o.settings.evmVersion = opts.evmVersion
+  }
+  return JSON.stringify(o)
 }


### PR DESCRIPTION
Add a way to pass the `evmVersion` parameter
to `solc` by:

1. Simplify the `Compiler.compileJSON()` interface from
`compileJSON(source, optimize)` to `compileJSON(source)`

Whether optimization is enabled is then always determined by
the `Compiler.optimize` object field which simplifies data flow.

2. Add a `Compiler.evmVersion` field and a setter and
make `compileJSON()` honor that.

Specifying `evmVersion` is useful when targetting an older
private chain with the latest `solc` or when using
an EVM-compatible chain that's slightly behind Ethereum
main-net in terms of features.

The unused `userAgent` variable in `onInternalCompilerLoaded` was
only removed to fix `npm run test` for `remix-solidity`'.