### PR TITLE
Small spelling typos

### DIFF
--- a/remix-lib/src/astWalker.js
+++ b/remix-lib/src/astWalker.js
@@ -11,7 +11,7 @@ function AstWalker () {
  * @param {Object} ast  - AST node
  * @param {Object or Function} callback  - if (Function) the function will be called for every node.
  *                                       - if (Object) callback[<Node Type>] will be called for
- *                                         every node of type <Node Type>. callback["*"] will be called fo all other nodes.
+ *                                         every node of type <Node Type>. callback["*"] will be called for all other nodes.
  *                                         in each case, if the callback returns false it does not descend into children.
  *                                         If no callback for the current type, children are visited.
  */

--- a/remix-lib/src/eventManager.js
+++ b/remix-lib/src/eventManager.js
@@ -6,12 +6,12 @@ function eventManager () {
 }
 
 /*
-   * Unregister a listenner.
+   * Unregister a listener.
    * Note that if obj is a function. the unregistration will be applied to the dummy obj {}.
    *
    * @param {String} eventName  - the event name
    * @param {Object or Func} obj - object that will listen on this event
-   * @param {Func} func         - function of the listenners that will be executed
+   * @param {Func} func         - function of the listeners that will be executed
 */
 eventManager.prototype.unregister = function (eventName, obj, func) {
   if (!this.registered[eventName]) {
@@ -29,12 +29,12 @@ eventManager.prototype.unregister = function (eventName, obj, func) {
 }
 
 /*
-   * Register a new listenner.
+   * Register a new listener.
    * Note that if obj is a function, the function registration will be associated with the dummy object {}
    *
    * @param {String} eventName  - the event name
    * @param {Object or Func} obj - object that will listen on this event
-   * @param {Func} func         - function of the listenners that will be executed
+   * @param {Func} func         - function of the listeners that will be executed
 */
 eventManager.prototype.register = function (eventName, obj, func) {
   if (!this.registered[eventName]) {
@@ -52,10 +52,10 @@ eventManager.prototype.register = function (eventName, obj, func) {
 
 /*
    * trigger event.
-   * Every listenner have their associated function executed
+   * Every listener have their associated function executed
    *
    * @param {String} eventName  - the event name
-   * @param {Array}j - argument that will be passed to the exectued function.
+   * @param {Array}j - argument that will be passed to the executed function.
 */
 eventManager.prototype.trigger = function (eventName, args) {
   if (!this.registered[eventName]) {

--- a/remix-lib/src/sourceMappingDecoder.js
+++ b/remix-lib/src/sourceMappingDecoder.js
@@ -70,7 +70,7 @@ SourceMappingDecoder.prototype.decompressAll = function (mapping) {
   * Retrieve line/column position of each source char
   *
   * @param {String} source - contract source code
-  * @return {Arrray} returns an array containing offset of line breaks
+  * @return {Array} returns an array containing offset of line breaks
   */
 SourceMappingDecoder.prototype.getLinebreakPositions = function (source) {
   var ret = []
@@ -81,7 +81,7 @@ SourceMappingDecoder.prototype.getLinebreakPositions = function (source) {
 }
 
 /**
- * Retrieve the line/colum position for the given source mapping
+ * Retrieve the line/column position for the given source mapping
  *
  * @param {Object} sourceLocation - object containing attributes {source} and {length}
  * @param {Array} lineBreakPositions - array returned by the function 'getLinebreakPositions'

--- a/remix-lib/src/util.js
+++ b/remix-lib/src/util.js
@@ -3,7 +3,7 @@ var ethutil = require('ethereumjs-util')
 
 /*
  contains misc util: @TODO should be splitted
-  - hex convertion
+  - hex conversion
   - binary search
   - CALL related look up
   - sha3 calculation


### PR DESCRIPTION
I was looking over `remix-lib` to use in a library that can feed both into an LSP server and client-side IDEs and came across these typos. 

I offer them if you are interested. 

Side note: one thing I don't see in `remix-lib/src/sourceMappingDecoder.js` is the inverse of `convertFromCharPosition()`, that is something that starts out with a line and column number and converts that into an offset. (VSCode for example starts off with positions in this format). 

Since this is trivial to write, I'll coding that in. If there's interest in adding this to remix-lib, give out a holler. 