### PR TITLE
[WIP] Add more position conversion functions

### DIFF
--- a/remix-astwalker/package.json
+++ b/remix-astwalker/package.json
@@ -32,6 +32,7 @@
     ]
   },
   "dependencies": {
+    "remix-lib": "^0.4.6",
     "@types/tape": "^4.2.33",
     "nyc": "^13.3.0",
     "tape": "^4.10.1",

--- a/remix-astwalker/src/@types/remix-lib/index.d.ts
+++ b/remix-astwalker/src/@types/remix-lib/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitiosn for the things we need from remix-lib
+
+declare module "remix-lib" {
+  export module util {
+    export function findLowerBound(target: number, array: Array<number>): number;
+  }
+}

--- a/remix-astwalker/src/types.ts
+++ b/remix-astwalker/src/types.ts
@@ -1,7 +1,25 @@
+// FIXME: should this be renamed to indicate its offset/length orientation?
+// Add "reaadonly property"?
 export interface Location {
   start: number;
   length: number;
   file: number;  // Would it be clearer to call this a file index?
+}
+
+// This is intended to be compatibile with VScode's Position.
+// However it is pretty common with other things too.
+// Note: File index is missing here
+export interface LineColPosition {
+  readonly line: number;
+  readonly character: number;
+}
+
+// This is intended to be compatibile with vscode's Range
+// However it is pretty common with other things too.
+// Note: File index is missing here
+export interface LineColRange {
+  readonly start: LineColPosition;
+  readonly end: LineColPosition;
 }
 
 export interface Node {

--- a/remix-astwalker/tests/resources/test.sol
+++ b/remix-astwalker/tests/resources/test.sol
@@ -1,0 +1,17 @@
+contract test {
+    int x;
+
+    int y;
+
+    function set(int _x) returns (int _r)
+    {
+        x = _x;
+        y = 10;
+        _r = x;
+    }
+
+    function get() returns (uint x, uint y)
+    {
+
+    }
+}

--- a/remix-astwalker/tests/sourceMappings.ts
+++ b/remix-astwalker/tests/sourceMappings.ts
@@ -1,24 +1,32 @@
 import tape from "tape";
-import { AstNode, isAstNode, SourceMappings, sourceLocationFromAstNode } from "../src";
+import {
+  AstNode, isAstNode,
+  LineColPosition, lineColPositionFromOffset,
+  LineColRange, Location,
+  SourceMappings, sourceLocationFromAstNode,
+  sourceLocationFromSrc
+} from "../src";
 import node from "./resources/newAST";
 
 tape("SourceMappings", (t: tape.Test) => {
   const source = node.source;
   const srcMappings = new SourceMappings(source);
-  t.test("SourceMappings constructor", (st: tape.Test) => {
-    st.plan(2)
-    st.equal(srcMappings.source, source, "sourceMappings object has source-code string");
-    st.deepEqual(srcMappings.lineBreaks,
-      [15, 26, 27, 38, 39, 81, 87, 103, 119, 135, 141, 142, 186, 192, 193, 199],
-      "sourceMappings has line-break offsets");
-    st.end();
-  });
-  t.test("SourceMappings functions", (st: tape.Test) => {
-    // st.plan(2)
+  t.test("SourceMappings conversions", (st: tape.Test) => {
+    st.plan(9);
+    const loc = <Location>{
+      start: 32,
+      length: 6,
+      file: 0
+    };
+
     const ast = node.ast;
-    st.deepEqual(sourceLocationFromAstNode(ast.nodes[0]),
-      { start: 0, length: 31, file: 0 },
-      "sourceLocationFromAstNode extracts a location");
+
+    st.deepEqual(lineColPositionFromOffset(0, srcMappings.lineBreaks),
+      <LineColPosition>{ line: 1, character: 1 },
+      "lineColPositionFromOffset degenerate case");
+    st.deepEqual(lineColPositionFromOffset(200, srcMappings.lineBreaks),
+      <LineColPosition>{ line: 17, character: 1 },
+      "lineColPositionFromOffset conversion");
 
     /* Typescript will keep us from calling sourceLocationFromAstNode
        with the wrong type. However, for non-typescript uses, we add
@@ -27,6 +35,48 @@ tape("SourceMappings", (t: tape.Test) => {
     */
     st.notOk(sourceLocationFromAstNode(<AstNode>null),
       "sourceLocationFromAstNode rejects an invalid astNode");
+
+    st.deepEqual(sourceLocationFromAstNode(ast.nodes[0]),
+      { start: 0, length: 31, file: 0 },
+      "sourceLocationFromAstNode extracts a location");
+    st.deepEqual(sourceLocationFromSrc("32:6:0"), loc,
+      "sourceLocationFromSrc conversion");
+    const startLC = <LineColPosition>{ line: 6, character: 6 };
+    st.deepEqual(srcMappings.srcToLineColumnRange("45:96:0"),
+      <LineColRange>{
+        start: startLC,
+        end: <LineColPosition>{ line: 11, character: 6 }
+      }, "srcToLineColumnRange end of line");
+    st.deepEqual(srcMappings.srcToLineColumnRange("45:97:0"),
+      <LineColRange>{
+        start: startLC,
+        end: <LineColPosition>{ line: 12, character: 1 }
+      }, "srcToLineColumnRange beginning of next line");
+    st.deepEqual(srcMappings.srcToLineColumnRange("45:98:0"),
+      <LineColRange>{
+        start: startLC,
+        end: <LineColPosition>{ line: 13, character: 1 }
+      }, "srcToLineColumnRange skip over empty line");
+    st.deepEqual(srcMappings.srcToLineColumnRange("-1:0:0"),
+      <LineColRange>{
+        start: null,
+        end: null
+      }, "srcToLineColumnRange invalid range");
+    st.end();
+  });
+
+  t.test("SourceMappings constructor", (st: tape.Test) => {
+    st.plan(2);
+    st.equal(srcMappings.source, source, "sourceMappings object has source-code string");
+    st.deepEqual(srcMappings.lineBreaks,
+      [15, 26, 27, 38, 39, 81, 87, 103, 119, 135, 141, 142, 186, 192, 193, 199],
+      "sourceMappings has line-break offsets");
+    st.end();
+  });
+  t.test("SourceMappings functions", (st: tape.Test) => {
+    st.plan(5);
+    const ast = node.ast;
+
     const loc = { start: 267, length: 20, file: 0 };
     let astNode = srcMappings.findNodeAtSourceLocation('ExpressionStatement', loc, ast);
     st.ok(isAstNode(astNode), "findsNodeAtSourceLocation finds something");
@@ -36,7 +86,6 @@ tape("SourceMappings", (t: tape.Test) => {
     let astNodes = srcMappings.nodesAtPosition(null, loc, ast);
     st.equal(astNodes.length, 2, "nodesAtPosition should find more than one astNode");
     st.ok(isAstNode(astNodes[0]), "nodesAtPosition returns only AST nodes");
-    // console.log(astNodes[0]);
     astNodes = srcMappings.nodesAtPosition("ExpressionStatement", loc, ast);
     st.equal(astNodes.length, 1, "nodesAtPosition filtered to a single nodeType");
     st.end();

--- a/remix-astwalker/tsconfig.json
+++ b/remix-astwalker/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["src"],
+  "exclude":  ["node_modules", "src/@types" ],
   "compilerOptions": {
     /* Basic Options */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
@@ -8,6 +9,7 @@
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     "outDir": "./dist",                       /* Redirect output structure to the directory. */
+
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": false,                   /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -15,7 +17,7 @@
     /* Module Resolution Options */
     "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
     "paths": { "remix-tests": ["./"] },       /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    "typeRoots": ["node_modules/@types"],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./@types", "node_modules/@types"], /* List of folders to include type definitions from. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "types": [
       "node"


### PR DESCRIPTION
- type LineColPosition,
- type LineColRange,
- function lineColPositionFromOffset
- function srcToLineColumnRange

And associated tests for these.

To discuss: 

One thing I would like to see is clarification of things in `remix-astWalker/src/types.ts` like `Location`. 

Here it means the interpretation of a solc-style AST-field `src`. I think then that should be made explicit like `solcLocation`. 

Although I personally like the solcLocation for its compactness, more common is a line/column based range. And here there are a couple of variations depending on whether columns and lines start at 0 or 1. 

Since I am using this stuff in a LSP oriented way, I have adopted their convention of both lines and columns starting at 1.  Personally I am okay with adding more kinds of things for other ways to represent a location. 