### PR TITLE
Init remix-simulator

### DIFF
--- a/remix-lib/src/execution/execution-context.js
+++ b/remix-lib/src/execution/execution-context.js
@@ -238,20 +238,6 @@ function ExecutionContext () {
     }
   }
 
-  this.checkpointAndCommit = function (cb, checkpointCount) {
-    // due to issue https://github.com/ethereumjs/ethereumjs-vm/issues/567
-    if (this.vm().stateManager._checkpointCount > (checkpointCount || 0)) {
-      return this.vm().stateManager.commit(() => {
-        cb()
-      })
-    }
-    this.vm().stateManager.checkpoint(() => {
-      this.vm().stateManager.commit(() => {
-        cb()
-      })
-    })
-  }
-
   this.currentblockGasLimit = function () {
     return this.blockGasLimit
   }

--- a/remix-lib/src/universalDapp.js
+++ b/remix-lib/src/universalDapp.js
@@ -1,5 +1,5 @@
 const async = require('async')
-const { BN, privateToAddress, isValidPrivate, stripHexPrefix } = require('ethereumjs-util')
+const { BN, privateToAddress, isValidPrivate, stripHexPrefix, toChecksumAddress } = require('ethereumjs-util')
 const crypto = require('crypto')
 const { EventEmitter } = require('events')
 
@@ -121,7 +121,7 @@ module.exports = class UniversalDApp {
         })
       })
 
-      this.accounts['0x' + address.toString('hex')] = { privateKey, nonce: 0 }
+      this.accounts[toChecksumAddress('0x' + address.toString('hex'))] = { privateKey, nonce: 0 }
     }
   }
 

--- a/remix-simulator/package.json
+++ b/remix-simulator/package.json
@@ -18,6 +18,7 @@
     "body-parser": "^1.18.2",
     "color-support": "^1.1.3",
     "commander": "^2.19.0",
+    "cors": "^2.8.5",
     "ethereumjs-util": "^5.1.2",
     "ethereumjs-vm": "3.0.0",
     "express": "^4.16.3",

--- a/remix-simulator/src/genesis.js
+++ b/remix-simulator/src/genesis.js
@@ -17,10 +17,8 @@ function generateBlock () {
     uncleHeaders: []
   })
 
-  executionContext.checkpointAndCommit(() => {
-    executionContext.vm().runBlock({ block: block, generate: true, skipBlockValidation: true, skipBalance: false }, function () {
-      executionContext.addBlock(block)
-    })
+  executionContext.vm().runBlock({ block: block, generate: true, skipBlockValidation: true, skipBalance: false }, function () {
+    executionContext.addBlock(block)
   })
 }
 

--- a/remix-simulator/src/methods/accounts.js
+++ b/remix-simulator/src/methods/accounts.js
@@ -12,18 +12,27 @@ var Accounts = function () {
   this.accountsKeys = {}
 
   executionContext.init({get: () => { return true }})
+}
+
+Accounts.prototype.init = async function () {
+  let setBalance = (account) => {
+    return new Promise((resolve, reject) => {
+      this.accountsKeys[ethJSUtil.toChecksumAddress(account.address)] = account.privateKey
+      this.accounts[ethJSUtil.toChecksumAddress(account.address)] = { privateKey: Buffer.from(account.privateKey.replace('0x', ''), 'hex'), nonce: 0 }
+
+      executionContext.vm().stateManager.getAccount(Buffer.from(account.address.toLowerCase().replace('0x', ''), 'hex'), (err, account) => {
+        if (err) {
+          throw new Error(err)
+        }
+        var balance = '0x56BC75E2D63100000'
+        account.balance = balance || '0xf00000000000000001'
+        resolve()
+      })
+    })
+  }
 
   for (let _account of this.accountsList) {
-    this.accountsKeys[_account.address.toLowerCase()] = _account.privateKey
-    this.accounts[_account.address.toLowerCase()] = { privateKey: Buffer.from(_account.privateKey.replace('0x', ''), 'hex'), nonce: 0 }
-
-    executionContext.vm().stateManager.getAccount(Buffer.from(_account.address.toLowerCase().replace('0x', ''), 'hex'), (err, account) => {
-      if (err) {
-        throw new Error(err)
-      }
-      var balance = '0x56BC75E2D63100000'
-      account.balance = balance || '0xf00000000000000001'
-    })
+    await setBalance(_account)
   }
 }
 

--- a/remix-simulator/src/methods/accounts.js
+++ b/remix-simulator/src/methods/accounts.js
@@ -45,7 +45,7 @@ Accounts.prototype.methods = function () {
 }
 
 Accounts.prototype.eth_accounts = function (payload, cb) {
-  return cb(null, this.accountsList.map((x) => x.address))
+  return cb(null, this.accountsList.map((x) => ethJSUtil.toChecksumAddress(x.address)))
 }
 
 Accounts.prototype.eth_getBalance = function (payload, cb) {

--- a/remix-simulator/src/methods/transactions.js
+++ b/remix-simulator/src/methods/transactions.js
@@ -26,6 +26,10 @@ Transactions.prototype.methods = function () {
 }
 
 Transactions.prototype.eth_sendTransaction = function (payload, cb) {
+  // from might be lowercased address (web3)
+  if (payload.params && payload.params.length > 0 && payload.params[0].from) {
+    payload.params[0].from = ethJSUtil.toChecksumAddress(payload.params[0].from)
+  }
   processTx(this.accounts, payload, false, cb)
 }
 
@@ -70,6 +74,10 @@ Transactions.prototype.eth_getCode = function (payload, cb) {
 }
 
 Transactions.prototype.eth_call = function (payload, cb) {
+  // from might be lowercased address (web3)
+  if (payload.params && payload.params.length > 0 && payload.params[0].from) {
+    payload.params[0].from = ethJSUtil.toChecksumAddress(payload.params[0].from)
+  }
   processTx(this.accounts, payload, true, cb)
 }
 

--- a/remix-simulator/src/methods/transactions.js
+++ b/remix-simulator/src/methods/transactions.js
@@ -5,7 +5,9 @@ var ethJSUtil = require('ethereumjs-util')
 var processTx = require('./txProcess.js')
 var BN = ethJSUtil.BN
 
-var Transactions = function (accounts) {
+var Transactions = function () {}
+
+Transactions.prototype.init = function (accounts) {
   this.accounts = accounts
 }
 

--- a/remix-simulator/src/provider.js
+++ b/remix-simulator/src/provider.js
@@ -12,16 +12,22 @@ const generateBlock = require('./genesis.js')
 
 var Provider = function (options) {
   this.Accounts = new Accounts()
+  this.Transactions = new Transactions()
 
   this.methods = {}
   this.methods = merge(this.methods, this.Accounts.methods())
   this.methods = merge(this.methods, (new Blocks(options)).methods())
   this.methods = merge(this.methods, (new Misc()).methods())
   this.methods = merge(this.methods, (new Net()).methods())
-  this.methods = merge(this.methods, (new Transactions(this.Accounts.accounts)).methods())
+  this.methods = merge(this.methods, (this.Transactions.methods()))
   this.methods = merge(this.methods, (new Whisper()).methods())
 
   generateBlock()
+}
+
+Provider.prototype.init = async function () {
+  await this.Accounts.init()
+  this.Transactions.init(this.Accounts.accounts)
 }
 
 Provider.prototype.sendAsync = function (payload, callback) {

--- a/remix-simulator/src/server.js
+++ b/remix-simulator/src/server.js
@@ -8,6 +8,7 @@ const log = require('./utils/logs.js')
 class Server {
   constructor (options) {
     this.provider = new Provider(options)
+    this.provider.init()
   }
 
   start (host, port) {

--- a/remix-simulator/src/server.js
+++ b/remix-simulator/src/server.js
@@ -9,7 +9,11 @@ const log = require('./utils/logs.js')
 class Server {
   constructor (options) {
     this.provider = new Provider(options)
-    this.provider.init()
+    this.provider.init().then(() => {
+      log('Provider initiated')
+    }).catch((error) => {
+      log(error)
+    })
   }
 
   start (host, port) {

--- a/remix-simulator/src/server.js
+++ b/remix-simulator/src/server.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const cors = require('cors')
 const bodyParser = require('body-parser')
 const app = express()
 const expressWs = require('express-ws')
@@ -14,6 +15,7 @@ class Server {
   start (host, port) {
     expressWs(app)
 
+    app.use(cors())
     app.use(bodyParser.urlencoded({extended: true}))
     app.use(bodyParser.json())
 

--- a/remix-tests/src/runTestSources.ts
+++ b/remix-tests/src/runTestSources.ts
@@ -10,15 +10,17 @@ import Web3 = require('web3')
 import { Provider } from 'remix-simulator'
 import { FinalResult } from './types'
 
-const createWeb3Provider = function () {
+const createWeb3Provider = async function () {
     let web3 = new Web3()
-    web3.setProvider(new Provider())
+    let provider = new Provider()
+    await provider.init()
+    web3.setProvider(provider)
     return web3
 }
 
-export function runTestSources(contractSources, testCallback, resultCallback, finalCallback, importFileCb, opts) {
+export async function runTestSources(contractSources, testCallback, resultCallback, finalCallback, importFileCb, opts) {
     opts = opts || {}
-    let web3 = opts.web3 || createWeb3Provider()
+    let web3 = opts.web3 || await createWeb3Provider()
     let accounts = opts.accounts || null
     async.waterfall([
         function getAccountList (next) {

--- a/remix-tests/tests/testRunner.ts
+++ b/remix-tests/tests/testRunner.ts
@@ -11,8 +11,9 @@ import { ResultsInterface, TestCbInterface, ResultCbInterface } from '../dist/in
 
 var provider = new Provider()
 
-function compileAndDeploy(filename: string, callback: Function) {
+async function compileAndDeploy(filename: string, callback: Function) {
   let web3: Web3 = new Web3()
+  await provider.init()
   web3.setProvider(provider)
   let compilationData: object
   let accounts: string[]


### PR DESCRIPTION
This PR make sure remix simulator provider is init (set value to test accounts) before using

 - remove use of checkpointAndCommit
 - add async `init` function for init the remix-simulator Provider
 - use cors for the remix-simulator CLI
 - use checksum address

