### PR TITLE
remix tests worked with compiler loaded using web-worker

### DIFF
--- a/remix-tests/src/compiler.ts
+++ b/remix-tests/src/compiler.ts
@@ -85,7 +85,7 @@ export function compileFileOrFiles(filename: string, isDirectory: boolean, opts:
     }
 }
 
-export function compileContractSources(sources: SrcIfc, importFileCb: any, opts: any, cb: Function) {
+export function compileContractSources(sources: SrcIfc, versionUrl: any, usingWorker: any, importFileCb: any, opts: any, cb: Function) {
     let compiler, filepath: string
     let accounts = opts.accounts || []
     // Iterate over sources keys. Inject test libraries. Inject test library import statements.
@@ -105,7 +105,7 @@ export function compileContractSources(sources: SrcIfc, importFileCb: any, opts:
     async.waterfall([
         function loadCompiler (next: Function) {
             compiler = new RemixCompiler(importFileCb)
-            compiler.onInternalCompilerLoaded()
+            compiler.loadVersion(usingWorker, versionUrl)
             // compiler.event.register('compilerLoaded', this, function (version) {
             next()
             // });

--- a/remix-tests/src/compiler.ts
+++ b/remix-tests/src/compiler.ts
@@ -106,9 +106,10 @@ export function compileContractSources(sources: SrcIfc, versionUrl: any, usingWo
         function loadCompiler (next: Function) {
             compiler = new RemixCompiler(importFileCb)
             compiler.loadVersion(usingWorker, versionUrl)
-            compiler.event.register('compilerLoaded', this, function (version) {
+            // @ts-ignore
+            compiler.event.register('compilerLoaded', this, (version) => {
                 next()
-            });
+            })
         },
         function doCompilation (next: Function) {
             // @ts-ignore

--- a/remix-tests/src/compiler.ts
+++ b/remix-tests/src/compiler.ts
@@ -106,9 +106,9 @@ export function compileContractSources(sources: SrcIfc, versionUrl: any, usingWo
         function loadCompiler (next: Function) {
             compiler = new RemixCompiler(importFileCb)
             compiler.loadVersion(usingWorker, versionUrl)
-            // compiler.event.register('compilerLoaded', this, function (version) {
-            next()
-            // });
+            compiler.event.register('compilerLoaded', this, function (version) {
+                next()
+            });
         },
         function doCompilation (next: Function) {
             // @ts-ignore

--- a/remix-tests/src/runTestSources.ts
+++ b/remix-tests/src/runTestSources.ts
@@ -18,7 +18,7 @@ const createWeb3Provider = async function () {
     return web3
 }
 
-export async function runTestSources(contractSources, testCallback, resultCallback, finalCallback, importFileCb, opts) {
+export async function runTestSources(contractSources, versionUrl, usingWorker, testCallback, resultCallback, finalCallback, importFileCb, opts) {
     opts = opts || {}
     let web3 = opts.web3 || await createWeb3Provider()
     let accounts = opts.accounts || null
@@ -31,7 +31,7 @@ export async function runTestSources(contractSources, testCallback, resultCallba
             })
         },
         function compile (next) {
-            compileContractSources(contractSources, importFileCb, { accounts }, next)
+            compileContractSources(contractSources, versionUrl, usingWorker, importFileCb, { accounts }, next)
         },
         function deployAllContracts (compilationResult, next) {
             deployAll(compilationResult, web3, (err, contracts) => {


### PR DESCRIPTION
Now we separately load the compiler using web worker before running tests.

fixes #1302 