### PR TITLE
twice error catching improved

### DIFF
--- a/remix-solidity/src/compiler/compiler-worker.js
+++ b/remix-solidity/src/compiler/compiler-worker.js
@@ -16,11 +16,7 @@ module.exports = function (self) {
 
         compileJSON = null
 
-        try {
-          self.importScripts(data.data)
-        } catch (exception) {
-          return JSON.stringify({ error: 'Uncaught JavaScript exception:\n' + exception })
-        }
+        self.importScripts(data.data)
         
         var compiler = solc(self.Module)
 

--- a/remix-solidity/src/compiler/compiler.js
+++ b/remix-solidity/src/compiler/compiler.js
@@ -298,9 +298,6 @@ function Compiler (handleImportCall) {
           break
       }
     })
-    worker.onerror = function (msg) {
-      compilationFinished({ error: 'Worker error: ' + msg.data })
-    }
     worker.addEventListener('error', function (msg) {
       compilationFinished({ error: 'Worker error: ' + msg.data })
     })


### PR DESCRIPTION
@LianaHus I have to removed the changes of #1333 because when import fails error is returned as `null` which is not caught/displayed on UI and compiler loading just gets going on.

Apart from that, double catching of worker event is improved.