### PR TITLE
Fixed a bug with the wrong event name

### DIFF
--- a/remix-debug/src/debugger/VmDebugger.js
+++ b/remix-debug/src/debugger/VmDebugger.js
@@ -180,7 +180,7 @@ class VmDebuggerLogic {
         storageViewer.storageRange(function (error, result) {
           if (!error) {
             storageJSON[address] = result
-            self.event.trigger('traceLengthUpdate', [storageJSON])
+            self.event.trigger('traceStorageUpdate', [storageJSON])
           }
         })
       }

--- a/remix-debug/src/debugger/VmDebugger.js
+++ b/remix-debug/src/debugger/VmDebugger.js
@@ -171,7 +171,7 @@ class VmDebuggerLogic {
       if (!self.storageResolver) return
 
       if (index !== self.traceLength - 1) {
-        return self.event.trigger('traceLengthUpdate', [{}])
+        return self.event.trigger('traceStorageUpdate', [{}])
       }
       var storageJSON = {}
       for (var k in self.addresses) {


### PR DESCRIPTION
The debug at Remix-ide of the new version can't display full storage changes, emmm... i think this is the reason