### PR TITLE
network id fixed

### DIFF
--- a/remix-lib/src/execution/execution-context.js
+++ b/remix-lib/src/execution/execution-context.js
@@ -151,12 +151,12 @@ function ExecutionContext () {
         var name = null
         if (err) name = 'Unknown'
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
-        else if (id === '1') name = 'Main'
-        else if (id === '2') name = 'Morden (deprecated)'
-        else if (id === '3') name = 'Ropsten'
-        else if (id === '4') name = 'Rinkeby'
-        else if (id === '5') name = 'Goerli'
-        else if (id === '42') name = 'Kovan'
+        else if (id === 1) name = 'Main'
+        else if (id === 2) name = 'Morden (deprecated)'
+        else if (id === 3) name = 'Ropsten'
+        else if (id === 4) name = 'Rinkeby'
+        else if (id === 5) name = 'Goerli'
+        else if (id === 42) name = 'Kovan'
         else name = 'Custom'
 
         if (id === '1') {


### PR DESCRIPTION
Without this, IDE shows each network as 'custom' for injected web3. Reason is `id` is now not a string.