### PR TITLE
Json interface unavailability handled

### DIFF
--- a/remix-tests/src/testRunner.ts
+++ b/remix-tests/src/testRunner.ts
@@ -136,12 +136,15 @@ function createRunList (jsonInterface: FunctionDescription[], fileAST: AstNode, 
 }
 
 export function runTest (testName: string, testObject: any, contractDetails: CompiledContract, fileAST: AstNode, opts: Options, testCallback: TestCbInterface, resultsCallback: ResultCbInterface): void {
-    const runList: RunListInterface[] = createRunList(testObject._jsonInterface, fileAST, testName)
     let passingNum: number = 0
     let failureNum: number = 0
     let timePassed: number = 0
+    const isJSONInterfaceAvailable = testObject && testObject.options && testObject.options.jsonInterface
+    if(!isJSONInterfaceAvailable)
+        return resultsCallback(new Error('Contract interface not available'), { passingNum, failureNum, timePassed })
+    
+    const runList: RunListInterface[] = createRunList(testObject.options.jsonInterface, fileAST, testName)
     const web3 = new Web3()
-
     const accts: TestResultInterface = {
       type: 'accountList',
       value: opts.accounts
@@ -260,10 +263,6 @@ export function runTest (testName: string, testObject: any, contractDetails: Com
             })
         }
     }, function(error) {
-        resultsCallback(error, {
-            passingNum: passingNum,
-            failureNum: failureNum,
-            timePassed: timePassed
-        })
+        resultsCallback(error, { passingNum, failureNum, timePassed })
     })
 }

--- a/remix-tests/tests/testRunner.ts
+++ b/remix-tests/tests/testRunner.ts
@@ -253,5 +253,31 @@ describe('testRunner', () => {
         assert.equal(results.failureNum, 0)
       })
     })
+
+    // Test `runTest` method without sending contract object (should throw error)
+    describe('runTest method without contract json interface', function () {
+      const filename: string = 'tests/various_sender/sender_and_value_test.sol'
+      const errorCallback: Function = (done) => {
+        return (err, _results) => {
+          if (err && err.message.includes('Contract interface not available')) { 
+            results = _results
+            done() 
+          }
+          else throw err
+        }
+      }
+      before(function (done) {
+        compileAndDeploy(filename, function (_err: Error | null | undefined, compilationData: object, contracts: any, asts: any, accounts: string[]) {
+          runTest('SenderAndValueTest', undefined, compilationData[filename]['SenderAndValueTest'], asts[filename], { accounts }, testCallback, errorCallback(done))
+        })
+      })
+
+      it('should have 0 passing tests', function () {
+        assert.equal(results.passingNum, 0)
+      })
+      it('should have 0 failing tests', function () {
+        assert.equal(results.failureNum, 0)
+      })
+    })
   })
 })


### PR DESCRIPTION
Used `options.jsonInterface` instead of internal property `_jsonInterface`

fixes #958 